### PR TITLE
Do not rely on block number; instead use the block's timestamp

### DIFF
--- a/contracts/DebtRegistry.sol
+++ b/contracts/DebtRegistry.sol
@@ -52,7 +52,7 @@ contract DebtRegistry is Pausable {
         uint underwriterRiskRating;
         address termsContract;
         bytes32 termsContractParameters;
-        uint issuanceBlockNumber;
+        uint issuanceBlockTimestamp;
     }
 
     // Primary registry mapping issuance hashes to their corresponding entries
@@ -133,7 +133,7 @@ contract DebtRegistry is Pausable {
             _underwriterRiskRating,
             _termsContract,
             _termsContractParameters,
-            block.number
+            block.timestamp
         );
 
         bytes32 issuanceHash = _getIssuanceHash(entry, _debtor, _salt);
@@ -240,7 +240,7 @@ contract DebtRegistry is Pausable {
             registry[issuanceHash].underwriterRiskRating,
             registry[issuanceHash].termsContract,
             registry[issuanceHash].termsContractParameters,
-            registry[issuanceHash].issuanceBlockNumber
+            registry[issuanceHash].issuanceBlockTimestamp
         );
     }
 
@@ -293,14 +293,14 @@ contract DebtRegistry is Pausable {
     }
 
     /**
-     * Returns the block number at which a debt agreement was issued
+     * Returns the timestamp of the block at which a debt agreement was issued.
      */
-    function getIssuanceBlockNumber(bytes32 issuanceHash)
+    function getIssuanceBlockTimestamp(bytes32 issuanceHash)
         public
         view
-        returns (uint)
+        returns (uint timestamp)
     {
-        return registry[issuanceHash].issuanceBlockNumber;
+        return registry[issuanceHash].issuanceBlockTimestamp;
     }
 
     /**

--- a/contracts/TermsContract.sol
+++ b/contracts/TermsContract.sol
@@ -54,23 +54,23 @@ interface TermsContract {
         address tokenAddress
     ) public returns (bool _success);
 
-     /// Returns the cumulative units-of-value expected to be repaid by any given blockNumber.
+     /// Returns the cumulative units-of-value expected to be repaid by a given block timestamp.
      ///  Note this is not a constant function -- this value can vary on basis of any number of
      ///  conditions (e.g. interest rates can be renegotiated if repayments are delinquent).
      /// @param  agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
-     /// @param  blockNumber uint. The block number for which repayment expectation is being queried.
-     /// @return uint256 The cumulative units-of-value expected to be repaid by the time the given blockNumber lapses.
+     /// @param  timestamp uint. The timestamp of the block for which repayment expectation is being queried.
+     /// @return uint256 The cumulative units-of-value expected to be repaid by the time the given timestamp lapses.
     function getExpectedRepaymentValue(
         bytes32 agreementId,
-        uint256 blockNumber
+        uint256 timestamp
     ) public view returns (uint256);
 
-     /// Returns the cumulative units-of-value repaid by the point at which a given blockNumber has lapsed.
+     /// Returns the cumulative units-of-value repaid by the point at which a given block timestamp has lapsed.
      /// @param  agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
-     /// @param blockNumber uint. The block number for which repayment value is being queried.
-     /// @return uint256 The cumulative units-of-value repaid by the time the given blockNumber lapsed.
+     /// @param timestamp uint. The timestamp of the block for which repayment value is being queried.
+     /// @return uint256 The cumulative units-of-value repaid by the time the given timestamp lapsed.
     function getValueRepaid(
         bytes32 agreementId,
-        uint256 blockNumber
+        uint256 timestamp
     ) public view returns (uint256);
 }

--- a/contracts/examples/NFTTermsContract.sol
+++ b/contracts/examples/NFTTermsContract.sol
@@ -71,13 +71,13 @@ contract NFTTermsContract {
 
     function getExpectedRepaymentValue(
         bytes32 agreementId,
-        uint256 blockNumber
+        uint256 blockTimestamp
     )
         public
         view
         returns (uint _expectedRepaymentValue)
     {
-        if (debtRegistry.getIssuanceBlockNumber(agreementId).add(SEVEN_DAYS_IN_BLOCKS) < blockNumber) {
+        if (debtRegistry.getIssuanceBlockTimestamp(agreementId).add(SEVEN_DAYS_IN_BLOCKS) < blockTimestamp) {
             return 1;
         } else {
             return 0;
@@ -86,7 +86,7 @@ contract NFTTermsContract {
 
     function getValueRepaid(
         bytes32 agreementId,
-        uint256 blockNumber
+        uint256 blockTimestamp
     )
         public
         view

--- a/contracts/examples/SimpleInterestTermsContract.sol
+++ b/contracts/examples/SimpleInterestTermsContract.sol
@@ -75,15 +75,15 @@ contract SimpleInterestTermsContract {
         return true;
     }
 
-     /// Returns the cumulative units-of-value expected to be repaid by any given blockNumber.
+     /// Returns the cumulative units-of-value expected to be repaid given a block'ss timestamp.
      ///  Note this is not a constant function -- this value can vary on basis of any number of
      ///  conditions (e.g. interest rates can be renegotiated if repayments are delinquent).
      /// @param  agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
-     /// @param  blockNumber uint. The block number for which repayment expectation is being queried.
-     /// @return uint256 The cumulative units-of-value expected to be repaid by the time the given blockNumber lapses.
+     /// @param  blockTimestamp uint. The timestamp of the block for which repayment expectation is being queried.
+     /// @return uint256 The cumulative units-of-value expected to be repaid given a block's timestamp.
     function getExpectedRepaymentValue(
         bytes32 agreementId,
-        uint256 blockNumber
+        uint256 blockTimestamp
     )
         public
         view
@@ -93,20 +93,20 @@ contract SimpleInterestTermsContract {
 
         var (principalPlusInterest, termLengthInBlocks) = unpackParameters(parameters);
 
-        if (debtRegistry.getIssuanceBlockNumber(agreementId).add(termLengthInBlocks) < blockNumber) {
+        if (debtRegistry.getIssuanceBlockTimestamp(agreementId).add(termLengthInBlocks) < blockTimestamp) {
             return principalPlusInterest;
         } else {
             return 0;
         }
     }
 
-     /// Returns the cumulative units-of-value repaid by the point at which a given blockNumber has lapsed.
-     /// @param  agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
-     /// @param blockNumber uint. The block number for which repayment value is being queried.
-     /// @return uint256 The cumulative units-of-value repaid by the time the given blockNumber lapsed.
+     /// Returns the cumulative units-of-value repaid by the point at which the timestamp of a given block has lapsed.
+     /// @param agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
+     /// @param blockTimestamp uint. The timestamp of the block for which repayment value is being queried.
+     /// @return uint256 The cumulative units-of-value repaid by the specified block timestamp.
     function getValueRepaid(
         bytes32 agreementId,
-        uint256 blockNumber
+        uint256 blockTimestamp
     )
         public
         view

--- a/contracts/examples/SimpleInterestTermsContract.sol
+++ b/contracts/examples/SimpleInterestTermsContract.sol
@@ -75,7 +75,7 @@ contract SimpleInterestTermsContract {
         return true;
     }
 
-     /// Returns the cumulative units-of-value expected to be repaid given a block'ss timestamp.
+     /// Returns the cumulative units-of-value expected to be repaid given a block's timestamp.
      ///  Note this is not a constant function -- this value can vary on basis of any number of
      ///  conditions (e.g. interest rates can be renegotiated if repayments are delinquent).
      /// @param  agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.

--- a/test/ts/integration/debt_kernel.ts
+++ b/test/ts/integration/debt_kernel.ts
@@ -285,6 +285,7 @@ contract("Debt Kernel (Integration Tests)", async (ACCOUNTS) => {
                 let relayerBalanceBefore: BigNumber;
 
                 let receipt: Web3.TransactionReceipt;
+                let block: Web3.BlockWithoutTransactionData;
 
                 let logs: ABIDecoder.DecodedLog[];
 
@@ -310,6 +311,7 @@ contract("Debt Kernel (Integration Tests)", async (ACCOUNTS) => {
                     );
 
                     receipt = await web3.eth.getTransactionReceipt(txHash);
+                    block = await web3.eth.getBlock(receipt.blockNumber);
 
                     logs = _.compact(ABIDecoder.decodeLogs(receipt.logs));
                 });
@@ -328,7 +330,7 @@ contract("Debt Kernel (Integration Tests)", async (ACCOUNTS) => {
                         underwriterRiskRating,
                         termsContract,
                         termsContractParameters,
-                        issuanceBlockNumber,
+                        issuanceBlockTimestamp,
                     ] = await debtRegistryContract
                             .get.callAsync(debtOrder.getIssuanceCommitment().getHash());
                     expect(version).to.equal(debtOrder.getIssuanceCommitment().getVersion());
@@ -341,8 +343,8 @@ contract("Debt Kernel (Integration Tests)", async (ACCOUNTS) => {
                         .equal(debtOrder.getIssuanceCommitment().getTermsContract());
                     expect(termsContractParameters).to
                         .equal(debtOrder.getIssuanceCommitment().getTermsContractParameters());
-                    expect(issuanceBlockNumber).to.bignumber
-                        .equal(receipt.blockNumber);
+                    expect(issuanceBlockTimestamp).to.bignumber
+                        .equal(block.timestamp);
                 });
 
                 it("should debit principal + creditor fee from creditor", async () => {

--- a/test/ts/unit/debt_registry.ts
+++ b/test/ts/unit/debt_registry.ts
@@ -207,11 +207,13 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
         describe("first agent inserts new entry into registry", () => {
             let res: Web3.TransactionReceipt;
             let entry: DebtRegistryEntry;
+            let block: Web3.BlockWithoutTransactionData;
 
             before(async () => {
                 entry = generateEntryFn();
                 const txHash = await insertEntryFn(entry, { from: AGENT_1 });
                 res = await web3.eth.getTransactionReceipt(txHash);
+                block = await web3.eth.getBlock(res.blockNumber);
             });
 
             it("should emit a log saying the debt is inserted", async () => {
@@ -230,7 +232,7 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
                         entry.getUnderwriterRiskRating(),
                         entry.getTermsContract(),
                         entry.getTermsContractParameters(),
-                        res.blockNumber,
+                        block.timestamp,
                 ];
 
                 _.forEach(retrievedEntry, (value: any, i: number) => {
@@ -251,11 +253,13 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
         describe("second agent inserts new entry into registry", () => {
             let res: Web3.TransactionReceipt;
             let entry: DebtRegistryEntry;
+            let block: Web3.BlockWithoutTransactionData;
 
             before(async () => {
                 entry = generateEntryFn();
                 const txHash = await insertEntryFn(entry, { from: AGENT_2 });
                 res = await web3.eth.getTransactionReceipt(txHash);
+                block = await web3.eth.getBlock(res.blockNumber);
             });
 
             it("should emit a log saying the debt is inserted", async () => {
@@ -274,7 +278,7 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
                         entry.getUnderwriterRiskRating(),
                         entry.getTermsContract(),
                         entry.getTermsContractParameters(),
-                        res.blockNumber,
+                        block.timestamp,
                 ];
 
                 _.forEach(retrievedEntry, (value: any, i: number) => {


### PR DESCRIPTION
This change reflects a request from the Zeppelin Solutions team and affects the following aspects of the code base:

1 - The `TermsContract` interface no longer relies on block numbers, but block timestamps
2- Entries in the `DebtRegistry` no longer store block numbers, but block timestamps

They submitted the following in requesting this change:

# Use of block numbers to express moments in time

> Implementors of the TermsContracts interface are expected to define repayment terms as a function of block numbers, as documented and seen in the function signatures of getExpectedRepaymentValue and getValueRepaid. To aid in this, entries in DebtRegistry record the issuance block number.

> Block timestamps have a small risk of miner manipulation within a range of minutes, so it is recommended to use block numbers for certain usecases where this manipulation is a security risk. It should be noted, however, that block times are not fixed, and thus block numbers are not a reliable unit of time. For example, the constant SEVEN_DAYS_IN_BLOCKS will not always represent the timespan of seven days that it is meant to.

> For the specific use case of determining repayment dates we think that the predictability of timestamps is preferable, and that it does not compromise the security of the system. Consider changing interfaces and data structures to use timestamps instead of block numbers.