### PR TITLE
Improve efficiency of revoking permissions

### DIFF
--- a/contracts/libraries/PermissionsLib.sol
+++ b/contracts/libraries/PermissionsLib.sol
@@ -22,6 +22,7 @@ pragma solidity 0.4.18;
 library PermissionsLib {
     struct Permissions {
         mapping (address => bool) authorized;
+        mapping (address => uint) agentToIndex;
         address[] authorizedAgents;
     }
 
@@ -31,6 +32,7 @@ library PermissionsLib {
         if (!self.authorized[agent]) {
             self.authorized[agent] = true;
             self.authorizedAgents.push(agent);
+            self.agentToIndex[agent] = self.authorizedAgents.length;
         }
     }
 
@@ -38,14 +40,10 @@ library PermissionsLib {
         internal
     {
         delete self.authorized[agent];
-        for (uint i = 0; i < self.authorizedAgents.length; i++) {
-            if (self.authorizedAgents[i] == agent) {
-                self.authorizedAgents[i] =
-                    self.authorizedAgents[self.authorizedAgents.length - 1];
-                self.authorizedAgents.length -= 1;
-                break;
-            }
-        }
+        self.authorizedAgents[self.agentToIndex[agent]] =
+          self.authorizedAgents[self.authorizedAgents.length - 1];
+        self.authorizedAgents.length -= 1;
+        delete self.agentToIndex[agent];
     }
 
     function isAuthorized(Permissions storage self, address agent)

--- a/contracts/libraries/PermissionsLib.sol
+++ b/contracts/libraries/PermissionsLib.sol
@@ -30,19 +30,29 @@ library PermissionsLib {
         internal
     {
         require(isNotAuthorized(self, agent));
+
         self.authorized[agent] = true;
         self.authorizedAgents.push(agent);
-        self.agentToIndex[agent] = self.authorizedAgents.length;
+        self.agentToIndex[agent] = self.authorizedAgents.length - 1;
     }
 
     function revokeAuthorization(Permissions storage self, address agent)
         internal
     {
+        /* We only want to do work in the case where the agent whose
+        authorization is being revoked had authorization permissions in the
+        first place */
         require(isAuthorized(self, agent));
+
+        uint indexOfAgentToRevoke = self.agentToIndex[agent];
+        uint indexOfAgentToMove = self.authorizedAgents.length - 1;
+        address agentToMove = self.authorizedAgents[indexOfAgentToMove];
+
         delete self.authorized[agent];
-        self.authorizedAgents[self.agentToIndex[agent]] =
-          self.authorizedAgents[self.authorizedAgents.length - 1];
+        self.authorizedAgents[indexOfAgentToRevoke] =
+            self.authorizedAgents[indexOfAgentToMove];
         self.authorizedAgents.length -= 1;
+        self.agentToIndex[agentToMove] = indexOfAgentToRevoke;
         delete self.agentToIndex[agent];
     }
 

--- a/contracts/libraries/PermissionsLib.sol
+++ b/contracts/libraries/PermissionsLib.sol
@@ -29,16 +29,16 @@ library PermissionsLib {
     function authorize(Permissions storage self, address agent)
         internal
     {
-        if (!self.authorized[agent]) {
-            self.authorized[agent] = true;
-            self.authorizedAgents.push(agent);
-            self.agentToIndex[agent] = self.authorizedAgents.length;
-        }
+        require(isNotAuthorized(self, agent));
+        self.authorized[agent] = true;
+        self.authorizedAgents.push(agent);
+        self.agentToIndex[agent] = self.authorizedAgents.length;
     }
 
     function revokeAuthorization(Permissions storage self, address agent)
         internal
     {
+        require(isAuthorized(self, agent));
         delete self.authorized[agent];
         self.authorizedAgents[self.agentToIndex[agent]] =
           self.authorizedAgents[self.authorizedAgents.length - 1];
@@ -52,6 +52,14 @@ library PermissionsLib {
         returns (bool)
     {
         return self.authorized[agent];
+    }
+
+    function isNotAuthorized(Permissions storage self, address agent)
+        internal
+        view
+        returns (bool)
+    {
+        return !isAuthorized(self, agent);
     }
 
     function getAuthorizedAgents(Permissions storage self)

--- a/test/ts/unit/debt_registry.ts
+++ b/test/ts/unit/debt_registry.ts
@@ -326,14 +326,14 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
                     res = await web3.eth.getTransactionReceipt(txHash);
                 });
 
-                it("should emit log saying third agent authorized", async () => {
+                it("should emit log saying fourth agent authorized", async () => {
                     const [logReturned] = ABIDecoder.decodeLogs(res.logs);
                     const logExpected = LogAddAuthorizedEditAgent(registry.address, AGENT_4);
 
                     expect(logReturned).to.deep.equal(logExpected);
                 });
 
-                it("should return first agent as authorized", async () => {
+                it("should return third and fourth agent as authorized", async () => {
                     await expect(registry.getAuthorizedEditAgents.callAsync())
                         .to.eventually.deep.equal([AGENT_3, AGENT_4]);
                 });


### PR DESCRIPTION
Revoking permissions previously was O(n). It has now been implemented to be O(1) because we store the index of the agent in a mapping housed in the `Permissions` struct.

This changes reflects the request from the Zeppelin audit. They write:

# Unbounded loop in PermissionsLib

> The revokeAuthorization function in PermissionsLib performs a linear search over an array of unbounded size. Through subsequent calls to authorize, the array could grow to a size so large that a call to revokeAuthorization would be prohibitively expensive and not fit in a block.

> Consider modifying the Permissions struct to include a mapping to save the index of each authorized address in the authorizedAgents array. In this way it will not be necessary to perform a linear search at all.