### PR TITLE
Clean up memory that's no longer used

### DIFF
--- a/contracts/libraries/PermissionsLib.sol
+++ b/contracts/libraries/PermissionsLib.sol
@@ -52,8 +52,7 @@ library PermissionsLib {
         delete self.authorized[agent];
 
         // Remove the agent from our collection of authorized agents.
-        self.authorizedAgents[indexOfAgentToRevoke] =
-            self.authorizedAgents[indexOfAgentToMove];
+        self.authorizedAgents[indexOfAgentToRevoke] = agentToMove;
 
         // Update our indices to reflect the above changes.
         self.agentToIndex[agentToMove] = indexOfAgentToRevoke;


### PR DESCRIPTION
This is a minor fix but ensures that we clean up our unused memory after removing an agent from our array of authorized agents.

I also added documentation to the revoke permissions method as it does involve a number of steps.

The folks at Zeppelin wrote the following in requesting this change:

# Edge case in PermissionsLib leaves data in storage

> The revokeAuthorization function in PermissionsLib removes the given address from the authorizedAgents array. The algorithm does not correctly consider the edge case when the array is reduced from length 1 to length 0. The new array length is correctly set to 0, but the address previously in the list will remain in storage, out of bounds.

> Although this is unlikely to cause a problem for the semantics of the contracts, consider zeroing out the last slot in the array before decrementing its length, similarly to what NonFungibleToken does.