### PR TITLE
Remove redundant agent authorizations + do not leverage generated typings in migrations

### DIFF
--- a/migrations/2_deploy_dharma_contracts.ts
+++ b/migrations/2_deploy_dharma_contracts.ts
@@ -1,20 +1,17 @@
-const PermissionsLib = artifacts.require("PermissionsLib");
-const DummyContract = artifacts.require("DummyContract");
-const DebtRegistry = artifacts.require("DebtRegistry");
-const DebtToken = artifacts.require("DebtToken");
-const DebtKernel = artifacts.require("DebtKernel");
-const RepaymentRouter = artifacts.require("RepaymentRouter");
-const TokenTransferProxy = artifacts.require("TokenTransferProxy");
-
 module.exports = (deployer: any, network: string, accounts: string[]) => {
-    const TX_DEFAULTS = { from: accounts[0], gas: 4000000 };
+    const PermissionsLib = artifacts.require("PermissionsLib");
+    const DummyContract = artifacts.require("DummyContract");
+    const DebtRegistry = artifacts.require("DebtRegistry");
+    const DebtToken = artifacts.require("DebtToken");
+    const DebtKernel = artifacts.require("DebtKernel");
+    const RepaymentRouter = artifacts.require("RepaymentRouter");
+    const TokenTransferProxy = artifacts.require("TokenTransferProxy");
 
-    deployer.deploy(DebtRegistry);
     deployer.deploy(PermissionsLib);
     deployer.link(PermissionsLib, DummyContract);
     deployer.deploy(DummyContract);
     deployer.link(PermissionsLib, DebtRegistry);
-    deployer.deploy(DebtRegistry).then(async () => {
+    return deployer.deploy(DebtRegistry).then(async () => {
         await deployer.deploy(DebtToken, DebtRegistry.address);
         await deployer.deploy(TokenTransferProxy);
         await deployer.deploy(RepaymentRouter, DebtRegistry.address, TokenTransferProxy.address);

--- a/migrations/3_deploy_test_contracts.ts
+++ b/migrations/3_deploy_test_contracts.ts
@@ -11,8 +11,6 @@ module.exports = (deployer: any, network: string, accounts: string[]) => {
     const MockTokenTransferProxyContract = artifacts.require("MockTokenTransferProxy");
     const MintableNonFungibleToken = artifacts.require("MintableNonFungibleToken");
 
-    const TX_DEFAULTS = { from: accounts[0], gas: 4000000 };
-
     const DUMMY_TOKEN_SUPPLY = 10 ** 27;
     const DUMMY_TOKEN_DECIMALS = 18;
 

--- a/migrations/3_deploy_test_contracts.ts
+++ b/migrations/3_deploy_test_contracts.ts
@@ -1,22 +1,20 @@
-import {DummyTokenRegistryContract} from "../types/generated/dummy_token_registry";
-
-const PermissionsLib = artifacts.require("PermissionsLib");
-const DummyContract = artifacts.require("DummyContract");
-const DummyToken = artifacts.require("DummyToken");
-const DummyTokenRegistry = artifacts.require("DummyTokenRegistry");
-const MockDebtRegistry = artifacts.require("MockDebtRegistry");
-const MockERC20Token = artifacts.require("MockERC20Token");
-const MockERC721Token = artifacts.require("MockERC721Token");
-const MockDebtToken = artifacts.require("MockDebtToken");
-const MockTermsContract = artifacts.require("MockTermsContract");
-const MockTokenTransferProxyContract = artifacts.require("MockTokenTransferProxy");
-const MintableNonFungibleToken = artifacts.require("MintableNonFungibleToken");
-
-const DUMMY_TOKEN_SUPPLY = 10 ** 27;
-const DUMMY_TOKEN_DECIMALS = 18;
-
 module.exports = (deployer: any, network: string, accounts: string[]) => {
+    const PermissionsLib = artifacts.require("PermissionsLib");
+    const DummyContract = artifacts.require("DummyContract");
+    const DummyToken = artifacts.require("DummyToken");
+    const DummyTokenRegistry = artifacts.require("DummyTokenRegistry");
+    const MockDebtRegistry = artifacts.require("MockDebtRegistry");
+    const MockERC20Token = artifacts.require("MockERC20Token");
+    const MockERC721Token = artifacts.require("MockERC721Token");
+    const MockDebtToken = artifacts.require("MockDebtToken");
+    const MockTermsContract = artifacts.require("MockTermsContract");
+    const MockTokenTransferProxyContract = artifacts.require("MockTokenTransferProxy");
+    const MintableNonFungibleToken = artifacts.require("MintableNonFungibleToken");
+
     const TX_DEFAULTS = { from: accounts[0], gas: 4000000 };
+
+    const DUMMY_TOKEN_SUPPLY = 10 ** 27;
+    const DUMMY_TOKEN_DECIMALS = 18;
 
     if (network !== "live") {
         deployer.link(PermissionsLib, DummyContract);
@@ -29,16 +27,14 @@ module.exports = (deployer: any, network: string, accounts: string[]) => {
         deployer.deploy(MockTokenTransferProxyContract);
         deployer.deploy(MintableNonFungibleToken);
         deployer.deploy(DummyTokenRegistry).then(async () => {
-            const dummyTokenRegistry = await DummyTokenRegistryContract.at(DummyTokenRegistry.address,
-                web3, TX_DEFAULTS);
-
+            const dummyTokenRegistry = await DummyTokenRegistry.deployed();
             const dummyREPToken = await DummyToken.new(
                 "Augur REP",
                 "REP",
                 DUMMY_TOKEN_DECIMALS,
                 DUMMY_TOKEN_SUPPLY,
             );
-            await dummyTokenRegistry.setTokenAddress.sendTransactionAsync("REP", dummyREPToken.address);
+            await dummyTokenRegistry.setTokenAddress("REP", dummyREPToken.address);
 
             const dummyMKRToken = await DummyToken.new(
                 "Maker DAO",
@@ -46,7 +42,7 @@ module.exports = (deployer: any, network: string, accounts: string[]) => {
                 DUMMY_TOKEN_DECIMALS,
                 DUMMY_TOKEN_SUPPLY,
             );
-            await dummyTokenRegistry.setTokenAddress.sendTransactionAsync("MKR", dummyMKRToken.address);
+            await dummyTokenRegistry.setTokenAddress("MKR", dummyMKRToken.address);
 
             const dummyZRXToken = await DummyToken.new(
                 "0x Token",
@@ -54,7 +50,7 @@ module.exports = (deployer: any, network: string, accounts: string[]) => {
                 DUMMY_TOKEN_DECIMALS,
                 DUMMY_TOKEN_SUPPLY,
             );
-            await dummyTokenRegistry.setTokenAddress.sendTransactionAsync("ZRX", dummyZRXToken.address);
+            await dummyTokenRegistry.setTokenAddress("ZRX", dummyZRXToken.address);
         });
     }
 };

--- a/migrations/4_authorize_contract_interactions.ts
+++ b/migrations/4_authorize_contract_interactions.ts
@@ -1,33 +1,33 @@
-import {DebtKernelContract} from "../types/generated/debt_kernel";
-import {DebtRegistryContract} from "../types/generated/debt_registry";
-import {DebtTokenContract} from "../types/generated/debt_token";
-import {RepaymentRouterContract} from "../types/generated/repayment_router";
-import {TokenTransferProxyContract} from "../types/generated/token_transfer_proxy";
-
 module.exports = (deployer: any, network: string, accounts: string[]) => {
+    const DebtRegistry = artifacts.require("DebtRegistry");
+    const DebtToken = artifacts.require("DebtToken");
+    const DebtKernel = artifacts.require("DebtKernel");
+    const TokenTransferProxy = artifacts.require("TokenTransferProxy");
+    const RepaymentRouter = artifacts.require("RepaymentRouter");
+
     const TX_DEFAULTS = { from: accounts[0], gas: 4000000 };
 
-    deployer.then(async () => {
-        const registry = await DebtRegistryContract.deployed(web3, TX_DEFAULTS);
-        const token = await DebtTokenContract.deployed(web3, TX_DEFAULTS);
-        const kernel = await DebtKernelContract.deployed(web3, TX_DEFAULTS);
-        const proxy = await TokenTransferProxyContract.deployed(web3, TX_DEFAULTS);
-        const router = await RepaymentRouterContract.deployed(web3, TX_DEFAULTS);
+    return deployer.then(async () => {
+        const registry = await DebtRegistry.deployed();
+        const token = await DebtToken.deployed();
+        const kernel = await DebtKernel.deployed();
+        const proxy = await TokenTransferProxy.deployed();
+        const router = await RepaymentRouter.deployed();
 
         // Authorize token contract to make mutations to the registry
-        await registry.addAuthorizedInsertAgent.sendTransactionAsync(token.address);
-        await registry.addAuthorizedEditAgent.sendTransactionAsync(token.address);
+        await registry.addAuthorizedInsertAgent(token.address);
+        await registry.addAuthorizedEditAgent(token.address);
 
         // Authorize kernel contract to mint and broker debt tokens
-        await token.addAuthorizedMintAgent.sendTransactionAsync(kernel.address);
+        await token.addAuthorizedMintAgent(kernel.address);
 
         // Set kernel to point at current debt token contract
-        await kernel.setDebtToken.sendTransactionAsync(token.address);
+        await kernel.setDebtToken(token.address);
 
         // Authorize kernel to make `transferFrom` calls on the token transfer proxy
-        await proxy.addAuthorizedTransferAgent.sendTransactionAsync(kernel.address);
+        await proxy.addAuthorizedTransferAgent(kernel.address);
 
         // Authorize repayment router to make `transferFrom` calls on the token transfer proxy
-        await proxy.addAuthorizedTransferAgent.sendTransactionAsync(router.address);
+        await proxy.addAuthorizedTransferAgent(router.address);
     });
 };

--- a/test/ts/integration/debt_kernel.ts
+++ b/test/ts/integration/debt_kernel.ts
@@ -165,11 +165,6 @@ contract("Debt Kernel (Integration Tests)", async (ACCOUNTS) => {
         await kernel.setDebtToken
             .sendTransactionAsync(debtTokenContract.address, { from: CONTRACT_OWNER });
 
-        await debtRegistryContract.addAuthorizedInsertAgent
-            .sendTransactionAsync(debtTokenContract.address, { from: CONTRACT_OWNER });
-        await debtRegistryContract.addAuthorizedEditAgent
-            .sendTransactionAsync(debtTokenContract.address, { from: CONTRACT_OWNER });
-
         await debtTokenContract.addAuthorizedMintAgent
             .sendTransactionAsync(kernel.address, { from: CONTRACT_OWNER });
 

--- a/test/ts/unit/debt_registry.ts
+++ b/test/ts/unit/debt_registry.ts
@@ -79,7 +79,7 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
     const TX_DEFAULTS = { from: CONTRACT_OWNER, gas: 4000000 };
 
     before(async () => {
-        const registryTruffleContract = await debtRegistryContract.deployed();
+        const registryTruffleContract = await debtRegistryContract.new();
 
         // The typings we use ingest vanilla Web3 contracts, so we convert the
         // contract instance deployed by truffle into a Web3 contract instance


### PR DESCRIPTION
In debugging a mysterious `revert` error, we discovered that:

1. There are several locations in which we redundantly add authorized agents to certain contracts' permissions.  Easy fix -- we either remove the redundant method calls, or make sure that those tests are working with a freshly deployed contract (as opposed to the contract deployed in the migrations).
2. `truffle test` silently runs a migration in which it saves artifacts to a temporary directory (which is _not_ `build/contracts`).  In contrast, when `truffle migrate` is run, artifacts are stored in `build/contracts`.  This creates idiosyncratic situations in which our generated typings (which pull contract artifacts stored in `build/contracts`) do not have access to the recently stored contract artifacts generated in `truffle test`'s silent migration.  Given that our tests rely heavily on our generated typings, we _need_ to run `truffle migrate` before running our tests, but we also can't stop `truffle test` from silently running a migration.  This means we need to make sure that our migrations don't rely on generated typings -- the migrations run by `truffle migrate` will succeed irrespective of whether we use our generated typings vs. truffle's generated wrappers, but the migrations run by `truffle test` will only succeed with truffle's generated wrappers.

This PR aims to remediate both of these issues.