### PR TITLE
Add checks in `insert` and in `modifyBeneficiary` to reject null beneficiaries.

### DIFF
--- a/contracts/DebtRegistry.sol
+++ b/contracts/DebtRegistry.sol
@@ -107,6 +107,11 @@ contract DebtRegistry is Pausable {
         _;
     }
 
+    modifier nonNullBeneficiary(address beneficiary) {
+        require(beneficiary != address(0));
+        _;
+    }
+
     /**
      * Inserts a new entry into the registry, if the entry is valid and sender is
      * authorized to make 'insert' mutations to the registry.
@@ -124,6 +129,7 @@ contract DebtRegistry is Pausable {
         public
         onlyAuthorizedToInsert
         whenNotPaused
+        nonNullBeneficiary(_beneficiary)
         returns (bytes32 _issuanceHash)
     {
         Entry memory entry = Entry(
@@ -164,6 +170,7 @@ contract DebtRegistry is Pausable {
         onlyAuthorizedToEdit
         whenNotPaused
         onlyExtantEntry(issuanceHash)
+        nonNullBeneficiary(newBeneficiary)
     {
         address previousBeneficiary = registry[issuanceHash].beneficiary;
 

--- a/test/ts/unit/debt_registry.ts
+++ b/test/ts/unit/debt_registry.ts
@@ -62,7 +62,7 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
 
     let registry: DebtRegistryContract;
 
-    // We define utility funcitons for the primary state-changing
+    // We define utility functions for the primary state-changing
     // operations permitted on the registry.
     let generateEntryFn: () => DebtRegistryEntry;
     let insertEntryFn: (entry: DebtRegistryEntry,

--- a/test/ts/unit/debt_registry.ts
+++ b/test/ts/unit/debt_registry.ts
@@ -250,6 +250,11 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
             });
         });
 
+        it("should throw when first agent inserts a new entry with a null beneficiary", async () => {
+          await expect(insertEntryFn(generateEntryFn(NULL_ADDRESS), { from: AGENT_1 }))
+              .to.eventually.be.rejectedWith(REVERT_ERROR);
+        });
+
         describe("second agent inserts new entry into registry", () => {
             let res: Web3.TransactionReceipt;
             let entry: DebtRegistryEntry;
@@ -294,6 +299,11 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
                 await expect(modifyEntryBeneficiaryFn(entry, AGENT_2, { from: AGENT_2 }))
                     .to.eventually.be.rejectedWith(REVERT_ERROR);
             });
+        });
+
+        it("should throw when second agent inserts a new entry with a null beneficiary", async () => {
+          await expect(insertEntryFn(generateEntryFn(NULL_ADDRESS), { from: AGENT_2 }))
+              .to.eventually.be.rejectedWith(REVERT_ERROR);
         });
 
         describe("owner authorizes agent(s) for editing entries", () => {

--- a/test/ts/unit/debt_registry.ts
+++ b/test/ts/unit/debt_registry.ts
@@ -64,7 +64,7 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
 
     // We define utility functions for the primary state-changing
     // operations permitted on the registry.
-    let generateEntryFn: () => DebtRegistryEntry;
+    let generateEntryFn: (beneficiary?: string) => DebtRegistryEntry;
     let insertEntryFn: (entry: DebtRegistryEntry,
                         options?: TxDataPayable)
         => Promise<string>;
@@ -96,9 +96,9 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
         // DebtRegistryEntries are given a random salt on construction --
         // we use the following function to generate arbitrary
         // DebtRegistryEntries without hash collisions.
-        generateEntryFn = () => {
+        generateEntryFn = (beneficiary: string = BENEFICIARY_1) => {
             return new DebtRegistryEntry({
-                beneficiary: BENEFICIARY_1,
+                beneficiary: beneficiary,
                 debtor: DEBTOR,
                 termsContract: TERMS_CONTRACT_ADDRESS,
                 termsContractParameters: ARBITRARY_TERMS_CONTRACT_PARAMS,

--- a/test/ts/unit/debt_registry.ts
+++ b/test/ts/unit/debt_registry.ts
@@ -250,11 +250,6 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
             });
         });
 
-        it("should throw when first agent inserts a new entry with a null beneficiary", async () => {
-          await expect(insertEntryFn(generateEntryFn(NULL_ADDRESS), { from: AGENT_1 }))
-              .to.eventually.be.rejectedWith(REVERT_ERROR);
-        });
-
         describe("second agent inserts new entry into registry", () => {
             let res: Web3.TransactionReceipt;
             let entry: DebtRegistryEntry;
@@ -299,11 +294,6 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
                 await expect(modifyEntryBeneficiaryFn(entry, AGENT_2, { from: AGENT_2 }))
                     .to.eventually.be.rejectedWith(REVERT_ERROR);
             });
-        });
-
-        it("should throw when second agent inserts a new entry with a null beneficiary", async () => {
-          await expect(insertEntryFn(generateEntryFn(NULL_ADDRESS), { from: AGENT_2 }))
-              .to.eventually.be.rejectedWith(REVERT_ERROR);
         });
 
         describe("owner authorizes agent(s) for editing entries", () => {
@@ -430,15 +420,28 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
                     { from: AGENT_4 })).to.eventually.be.rejectedWith(REVERT_ERROR);
             });
 
-            it("should throw when third agent specifies a null beneficiary when trying to modify an entry", async () => {
-              await expect(modifyEntryBeneficiaryFn(generateEntryFn(NULL_ADDRESS), AGENT_3))
-                  .to.eventually.be.rejectedWith(REVERT_ERROR);
+            describe("the beneficiary specified is null", () => {
+                it("should throw when the second agent attempts to inserts a new entry", async () => {
+                  await expect(insertEntryFn(generateEntryFn(NULL_ADDRESS), { from: AGENT_2 }))
+                      .to.eventually.be.rejectedWith(REVERT_ERROR);
+                });
+
+                it("should throw when the first agent attempts to insert a new entry", async () => {
+                  await expect(insertEntryFn(generateEntryFn(NULL_ADDRESS), { from: AGENT_1 }))
+                      .to.eventually.be.rejectedWith(REVERT_ERROR);
+                });
+
+                it("should throw when third agent tries to modify an entry", async () => {
+                  await expect(modifyEntryBeneficiaryFn(generateEntryFn(NULL_ADDRESS), AGENT_3))
+                      .to.eventually.be.rejectedWith(REVERT_ERROR);
+                });
+
+                it("should throw when fourth agent tries to modify an entry", async () => {
+                  await expect(modifyEntryBeneficiaryFn(generateEntryFn(NULL_ADDRESS), AGENT_4))
+                      .to.eventually.be.rejectedWith(REVERT_ERROR);
+                });
             });
 
-            it("should throw when fourth agent specifies a null beneficiary when trying to modify an entry", async () => {
-              await expect(modifyEntryBeneficiaryFn(generateEntryFn(NULL_ADDRESS), AGENT_4))
-                  .to.eventually.be.rejectedWith(REVERT_ERROR);
-            });
         });
 
         describe("owner revokes second agent from inserting entries", () => {

--- a/test/ts/unit/debt_registry.ts
+++ b/test/ts/unit/debt_registry.ts
@@ -98,7 +98,7 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
         // DebtRegistryEntries without hash collisions.
         generateEntryFn = (beneficiary: string = BENEFICIARY_1) => {
             return new DebtRegistryEntry({
-                beneficiary: beneficiary,
+                beneficiary,
                 debtor: DEBTOR,
                 termsContract: TERMS_CONTRACT_ADDRESS,
                 termsContractParameters: ARBITRARY_TERMS_CONTRACT_PARAMS,

--- a/test/ts/unit/debt_registry.ts
+++ b/test/ts/unit/debt_registry.ts
@@ -429,6 +429,16 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
                 await expect(insertEntryFn(generateEntryFn(),
                     { from: AGENT_4 })).to.eventually.be.rejectedWith(REVERT_ERROR);
             });
+
+            it("should throw when third agent specifies a null beneficiary when trying to modify an entry", async () => {
+              await expect(modifyEntryBeneficiaryFn(generateEntryFn(NULL_ADDRESS), AGENT_3))
+                  .to.eventually.be.rejectedWith(REVERT_ERROR);
+            });
+
+            it("should throw when fourth agent specifies a null beneficiary when trying to modify an entry", async () => {
+              await expect(modifyEntryBeneficiaryFn(generateEntryFn(NULL_ADDRESS), AGENT_4))
+                  .to.eventually.be.rejectedWith(REVERT_ERROR);
+            });
         });
 
         describe("owner revokes second agent from inserting entries", () => {


### PR DESCRIPTION
There is now a modifier that ensures `insert` and `modifyBeneficiary` do not specify a null beneficiary.