### PR TITLE
Partially address concerns Zeppelin raised concerning the external query gas limit

### DIFF
--- a/contracts/DebtKernel.sol
+++ b/contracts/DebtKernel.sol
@@ -644,7 +644,7 @@ contract DebtKernel is Pausable {
         view
         returns (uint _balance)
     {
-        // Limit gas to prevent reentrancy
+        // Limit gas to prevent reentrancy.
         return ERC20(token).balanceOf.gas(EXTERNAL_QUERY_GAS_LIMIT)(owner);
     }
 

--- a/contracts/DebtKernel.sol
+++ b/contracts/DebtKernel.sol
@@ -639,6 +639,7 @@ contract DebtKernel is Pausable {
         address owner
     )
         internal
+        view
         returns (uint _balance)
     {
         // Limit gas to prevent reentrancy
@@ -653,6 +654,7 @@ contract DebtKernel is Pausable {
         address owner
     )
         internal
+        view
         returns (uint _allowance)
     {
         // Limit gas to prevent reentrancy

--- a/contracts/DebtKernel.sol
+++ b/contracts/DebtKernel.sol
@@ -657,7 +657,7 @@ contract DebtKernel is Pausable {
         view
         returns (uint _allowance)
     {
-        // Limit gas to prevent reentrancy
-        return ERC20(token).allowance(owner, TOKEN_TRANSFER_PROXY);
+        // Limit gas to prevent reentrancy.
+        return ERC20(token).allowance.gas(EXTERNAL_QUERY_GAS_LIMIT)(owner, TOKEN_TRANSFER_PROXY);
     }
 }

--- a/contracts/DebtKernel.sol
+++ b/contracts/DebtKernel.sol
@@ -65,7 +65,9 @@ contract DebtKernel is Pausable {
     // solhint-disable-next-line var-name-mixedcase
     address public TOKEN_TRANSFER_PROXY;
     bytes32 constant public NULL_ISSUANCE_HASH = bytes32(0);
-    uint16 constant public EXTERNAL_QUERY_GAS_LIMIT = 4999;    // Changes to state require at least 5000 gas
+
+    /* TODO(kayvon): we should rely on static call to prevent reentrancy and not this arbitrary gas limit. */
+    uint16 constant public EXTERNAL_QUERY_GAS_LIMIT = 8000;
 
     mapping (bytes32 => bool) public issuanceCancelled;
     mapping (bytes32 => bool) public debtOrderCancelled;

--- a/contracts/DebtKernel.sol
+++ b/contracts/DebtKernel.sol
@@ -66,9 +66,10 @@ contract DebtKernel is Pausable {
     address public TOKEN_TRANSFER_PROXY;
     bytes32 constant public NULL_ISSUANCE_HASH = bytes32(0);
 
-    /* TODO(kayvon): Remove the need to impose a gas limit once the `view`
-    keyword actually compiles down to a static call, thus preventing reentrancy
-    ipso facto. */
+    /* NOTE(kayvon): Currently, the `view` keyword does not actually enforce the
+    static nature of the method; this will change in the future, but for now, in
+    order to prevent reentrancy we'll need to arbitrarily set an upper bound on
+    the gas limit allotted for certain method calls. */
     uint16 constant public EXTERNAL_QUERY_GAS_LIMIT = 8000;
 
     mapping (bytes32 => bool) public issuanceCancelled;

--- a/contracts/DebtKernel.sol
+++ b/contracts/DebtKernel.sol
@@ -66,7 +66,9 @@ contract DebtKernel is Pausable {
     address public TOKEN_TRANSFER_PROXY;
     bytes32 constant public NULL_ISSUANCE_HASH = bytes32(0);
 
-    /* TODO(kayvon): we should rely on static call to prevent reentrancy and not this arbitrary gas limit. */
+    /* TODO(kayvon): Remove the need to impose a gas limit once the `view`
+    keyword actually compiles down to a static call, thus preventing reentrancy
+    ipso facto. */
     uint16 constant public EXTERNAL_QUERY_GAS_LIMIT = 8000;
 
     mapping (bytes32 => bool) public issuanceCancelled;


### PR DESCRIPTION
- Up the amount to 8000
- Mark both functions as view so they'll eventually compile down to static calls
- Actually enforce the gas limit for `getAllowance`