### PR TITLE
De-duplicate `ownerOf()` logic from `DebtToken.sol`

### DIFF
--- a/contracts/DebtToken.sol
+++ b/contracts/DebtToken.sol
@@ -137,7 +137,7 @@ contract DebtToken is MintableNonFungibleToken, Pausable {
     }
 
     /**
-     * We oveerride the core ownership transfer method of the parent non-fungible token
+     * We override the core ownership transfer method of the parent non-fungible token
      * contract so that it mutates the debt registry every time a token is transferred
      */
     function _setTokenOwner(uint _tokenId, address _to)
@@ -146,17 +146,7 @@ contract DebtToken is MintableNonFungibleToken, Pausable {
         if (registry.getBeneficiary(bytes32(_tokenId)) != _to) {
             registry.modifyBeneficiary(bytes32(_tokenId), _to);
         }
-    }
 
-    /**
-     * We oveerride the core ownership getter of the parent non-fungible token
-     * contract so that it retrieves the debt's current beneficiary from the debt registry
-     */
-    function _ownerOf(uint _tokenId)
-        internal
-        view
-        returns (address _owner)
-    {
-        return registry.getBeneficiary(bytes32(_tokenId));
+        super._setTokenOwner(_tokenId, _to);
     }
 }

--- a/test/ts/unit/debt_token.ts
+++ b/test/ts/unit/debt_token.ts
@@ -397,24 +397,14 @@ contract("Debt Token (Unit Tests)", (ACCOUNTS) => {
         before(resetAndInitState);
 
         describe("user calls ownerOf on a given tokenId", async () => {
-            before(async () => {
-                mockRegistry.mockGetBeneficiaryReturnValueFor.
-                    sendTransactionAsync(debtEntries[0].getIssuanceHash(), TOKEN_OWNER_3);
-            });
-
-            it("should return what registry says debt's beneficiary is", async () => {
-                await expect(debtToken.ownerOf.callAsync(debtEntries[0].getTokenId()))
-                    .to.eventually.equal(TOKEN_OWNER_3);
+            it("should return the owner of the given token at that point in time", async () => {
+                await expect(debtToken.ownerOf.callAsync(debtEntries[1].getTokenId()))
+                    .to.eventually.equal(TOKEN_OWNER_2);
             });
 
             describe("...when token is burned / doesn't exist", async () => {
-                before(async () => {
-                    await mockRegistry.mockGetBeneficiaryReturnValueFor.
-                        sendTransactionAsync(debtEntries[0].getIssuanceHash(), NULL_ADDRESS);
-                });
-
                 it("should return null address", async () => {
-                    await expect(debtToken.ownerOf.callAsync(debtEntries[0].getTokenId()))
+                    await expect(debtToken.ownerOf.callAsync(NONEXISTENT_TOKEN_ID))
                         .to.eventually.equal(NULL_ADDRESS);
                 });
             });


### PR DESCRIPTION
Logic in the `DebtToken.sol` contract is fairly brittle in that, by overriding certain functions of the class from which it inherits, it tries to shoehorn the DebtRegistry as the primary data layer for the NFT.  Our auditors suggested to instead maintain parallel data stores for the debt tokens generated via Dharma protocol -- one in the actual DebtRegistry, and another in the `DebtToken` file itself.   This fix attempts to do so.

For reference, per the OpenZeppelin audit:

# Duplication of owner logic in DebtToken

> DebtToken extends NonFungibleToken and redefines the latter’s _setTokenOwner and _ownerOf internal functions, so that they modify the DebtRegistry instead of the NFT’s own tracking of ownership. This seems to result in coherent behavior, but we think it’s an unnecessary meddling with NonFungibleToken’s semantics, and could eventually cause some obscure hard-to-spot issues.

> We would suggest to remove the redefinition of _ownerOf, and to modify _setTokenOwner so that it runs super._setTokenOwner() additionally to the calls on the registry. In this way the registry is kept in sync with the token’s tracking of ownership, but merely by intercepting changes of ownership, instead of entirely replacing that part of the token’s implementation.