### PR TITLE
Make Pausable operations more consistent in DebtRegistry and DebtToken

### DIFF
--- a/contracts/DebtRegistry.sol
+++ b/contracts/DebtRegistry.sol
@@ -206,7 +206,6 @@ contract DebtRegistry is Pausable {
      */
     function revokeInsertAgentAuthorization(address agent)
         public
-        whenNotPaused
         onlyOwner
     {
         entryInsertPermissions.revokeAuthorization(agent);

--- a/contracts/DebtToken.sol
+++ b/contracts/DebtToken.sol
@@ -137,6 +137,18 @@ contract DebtToken is MintableNonFungibleToken, Pausable {
     }
 
     /**
+     * We override the core approvals method of the parent non-fungible token
+     * contract to allow its functionality to be frozen in the case of an emergency
+     */
+    function _approve(address _to, uint _tokenId)
+        internal
+        whenNotPaused
+    {
+        super._approve(_to, _tokenId);
+    }
+
+
+    /**
      * We oveerride the core ownership transfer method of the parent non-fungible token
      * contract so that it mutates the debt registry every time a token is transferred
      */


### PR DESCRIPTION
In this PR, we 
- Remove the `whenNotPaused` check from the `revokeInsertAgentAuthorization` method, given that none of the other `PermissionsLib` related methods in `DebtRegistry` have pausable operations.  This is secure because the `revokeInsertAgentAuthorization` method can only be activated by the contract's `owner` -- namely, Dharma Labs.
- Override the `_approve()` method of the `DebtToken.sol` such that approvals can be paused at any given point in time.

In the words of our auditors:

# Inconsistent Pausable operations in DebtRegistry and DebtToken
> The main functionality of DebtRegistry is correctly guarded with whenNotPaused modifiers to ensure they cannot be used when the contract is in “paused” state. There are other non-constant functions in the contract (those related to permissions) which are inconsistently guarded: revokeInsertAgentAuthorization has the whenNotPaused modifier, but none of the others do. Consider either removing the modifier in this function or adding it to the other three permissions-related functions in the contract for consistency.
> Likewise, the contract DebtToken prevents all kinds of transfers during the “paused” state by adding the modifier to the _clearApprovalAndTransfer function. There is one additional operation which should likely be affected by pausing as well: approve. Consider adding the whenNotPaused modifier to the approve function in DebtToken.