### PR TITLE
remove unused `Issuance` data structure from `DebtRegistry.sol`

### DIFF
--- a/contracts/DebtRegistry.sol
+++ b/contracts/DebtRegistry.sol
@@ -35,16 +35,6 @@ contract DebtRegistry is Pausable {
     using SafeMath for uint;
     using PermissionsLib for PermissionsLib.Permissions;
 
-    struct Issuance {
-        address version;
-        address debtor;
-        address underwriter;
-        uint underwriterRiskRating;
-        address termsContract;
-        bytes32 termsContractParameters;
-        uint salt;
-    }
-
     struct Entry {
         address version;
         address beneficiary;


### PR DESCRIPTION
The `Issuance` data structure was unnecessarily duplicated in the `DebtRegistry.sol` file.  We remove for both code cleanliness and avoiding any logic inconsistencies.

For reference, commentary from our auditors:

# Duplicate declaration of data structures
> There are two Issuance structs, one defined in DebtKernel and another one in DebtRegistry, which are basically the same, except for one member. This duplication could cause problems if the two data structure definitions ever get out of sync during development. Consider having one definition in a central place, together with the relevant operations defined as functions.