### PR TITLE
Fixes and improvements to remove-nft-terms branch

### DIFF
--- a/contracts/RepaymentRouter.sol
+++ b/contracts/RepaymentRouter.sol
@@ -54,14 +54,6 @@ contract RepaymentRouter is Pausable {
         address _token
     );
 
-    event LogNFTRepayment(
-        bytes32 indexed _agreementId,
-        address indexed _payer,
-        address indexed _beneficiary,
-        uint _tokenId,
-        address _token
-    );
-
     event LogError(uint8 indexed _errorId, bytes32 indexed _agreementId);
 
     /**

--- a/contracts/TermsContract.sol
+++ b/contracts/TermsContract.sol
@@ -48,10 +48,10 @@ interface TermsContract {
         uint256 timestamp
     ) public view returns (uint256);
 
-     /// Returns the cumulative units-of-value repaid by the point at which this method is called
+     /// Returns the cumulative units-of-value repaid by the point at which this method is called.
      /// @param  agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
      /// @return uint256 The cumulative units-of-value repaid up until now.
-    function getValueRepaid(
+    function getValueRepaidToDate(
         bytes32 agreementId
     ) public view returns (uint256);
 }

--- a/contracts/examples/SimpleInterestTermsContract.sol
+++ b/contracts/examples/SimpleInterestTermsContract.sol
@@ -20,9 +20,10 @@ pragma solidity 0.4.18;
 
 import "zeppelin-solidity/contracts/math/SafeMath.sol";
 import "../DebtRegistry.sol";
+import "../TermsContract.sol";
 
 
-contract SimpleInterestTermsContract {
+contract SimpleInterestTermsContract is TermsContract {
     using SafeMath for uint;
 
     mapping (bytes32 => uint) valueRepaid;

--- a/contracts/examples/SimpleInterestTermsContract.sol
+++ b/contracts/examples/SimpleInterestTermsContract.sol
@@ -101,12 +101,10 @@ contract SimpleInterestTermsContract is TermsContract {
         }
     }
 
-     /// Returns the cumulative units-of-value repaid by the point at which the timestamp of a given block has lapsed.
+     /// Returns the cumulative units-of-value repaid to date.
      /// @param agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
      /// @return uint256 The cumulative units-of-value repaid by the specified block timestamp.
-    function getValueRepaid(
-        bytes32 agreementId
-    )
+    function getValueRepaidToDate(bytes32 agreementId)
         public
         view
         returns (uint _valueRepaid)

--- a/contracts/test/mocks/MockDebtToken.sol
+++ b/contracts/test/mocks/MockDebtToken.sol
@@ -140,7 +140,7 @@ contract MockDebtToken is MockContract {
         bytes32 _s
     )
         public
-        view
+        pure
         returns (bytes32 callSig)
     {
         return keccak256(

--- a/test/ts/integration/repayment_router.ts
+++ b/test/ts/integration/repayment_router.ts
@@ -192,7 +192,7 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
             });
 
             it("should not register repayment with terms contract", async () => {
-                await expect(termsContract.getValueRepaid.callAsync(
+                await expect(termsContract.getValueRepaidToDate.callAsync(
                     agreementId,
                     new BigNumber(receipt.blockNumber),
                 )).to.eventually.bignumber.equal(0);
@@ -256,7 +256,7 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
                 });
 
                 it("should not register repayment with terms contract", async () => {
-                    await expect(termsContract.getValueRepaid.callAsync(
+                    await expect(termsContract.getValueRepaidToDate.callAsync(
                         agreementId,
                         new BigNumber(receipt.blockNumber),
                     )).to.eventually.bignumber.equal(0);
@@ -298,7 +298,7 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
                 });
 
                 it("should not register repayment with terms contract", async () => {
-                    await expect(termsContract.getValueRepaid.callAsync(
+                    await expect(termsContract.getValueRepaidToDate.callAsync(
                         agreementId,
                         new BigNumber(receipt.blockNumber),
                     )).to.eventually.bignumber.equal(0);
@@ -334,7 +334,7 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
                 });
 
                 it("should register repayment with terms contract", async () => {
-                    await expect(termsContract.getValueRepaid.callAsync(
+                    await expect(termsContract.getValueRepaidToDate.callAsync(
                         agreementId, new BigNumber(receipt.blockNumber)))
                         .to.eventually.bignumber.equal(Units.ether(1.1));
                 });

--- a/test/ts/integration/repayment_router.ts
+++ b/test/ts/integration/repayment_router.ts
@@ -179,7 +179,6 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
             it("should not register repayment with terms contract", async () => {
                 await expect(termsContract.getValueRepaidToDate.callAsync(
                     agreementId,
-                    new BigNumber(receipt.blockNumber),
                 )).to.eventually.bignumber.equal(0);
             });
         });
@@ -243,7 +242,6 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
                 it("should not register repayment with terms contract", async () => {
                     await expect(termsContract.getValueRepaidToDate.callAsync(
                         agreementId,
-                        new BigNumber(receipt.blockNumber),
                     )).to.eventually.bignumber.equal(0);
                 });
             });
@@ -285,7 +283,6 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
                 it("should not register repayment with terms contract", async () => {
                     await expect(termsContract.getValueRepaidToDate.callAsync(
                         agreementId,
-                        new BigNumber(receipt.blockNumber),
                     )).to.eventually.bignumber.equal(0);
                 });
             });
@@ -320,8 +317,7 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
 
                 it("should register repayment with terms contract", async () => {
                     await expect(termsContract.getValueRepaidToDate.callAsync(
-                        agreementId, new BigNumber(receipt.blockNumber)))
-                        .to.eventually.bignumber.equal(Units.ether(1.1));
+                        agreementId)).to.eventually.bignumber.equal(Units.ether(1.1));
                 });
 
                 it("should emit repayment log", () => {

--- a/test/ts/integration/repayment_router.ts
+++ b/test/ts/integration/repayment_router.ts
@@ -12,8 +12,6 @@ import {DebtRegistryContract} from "../../../types/generated/debt_registry";
 import {DebtTokenContract} from "../../../types/generated/debt_token";
 import {DummyTokenContract} from "../../../types/generated/dummy_token";
 import {DummyTokenRegistryContract} from "../../../types/generated/dummy_token_registry";
-import {MintableNonFungibleTokenContract} from "../../../types/generated/mintable_non_fungible_token";
-import {NFTTermsContractContract} from "../../../types/generated/n_f_t_terms_contract";
 import {RepaymentRouterContract} from "../../../types/generated/repayment_router";
 import {SimpleInterestTermsContractContract} from "../../../types/generated/simple_interest_terms_contract";
 import {TokenTransferProxyContract} from "../../../types/generated/token_transfer_proxy";
@@ -27,7 +25,7 @@ import {BigNumberSetup} from "../test_utils/bignumber_setup";
 import ChaiSetup from "../test_utils/chai_setup";
 import {INVALID_OPCODE, REVERT_ERROR} from "../test_utils/constants";
 
-import {LogError, LogNFTRepayment, LogRepayment} from "../logs/repayment_router";
+import {LogError, LogRepayment} from "../logs/repayment_router";
 
 import leftPad = require("left-pad");
 
@@ -39,7 +37,6 @@ const expect = chai.expect;
 BigNumberSetup.configure();
 
 const simpleInterestTermsContract = artifacts.require("SimpleInterestTermsContract");
-const nftTermsContract = artifacts.require("NFTTermsContract");
 const repaymentRouterContract = artifacts.require("RepaymentRouter");
 
 contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
@@ -47,9 +44,7 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
     let kernel: DebtKernelContract;
     let debtToken: DebtTokenContract;
     let principalToken: DummyTokenContract;
-    let principalNFT: MintableNonFungibleTokenContract;
     let termsContract: SimpleInterestTermsContractContract;
-    let termsContractNFT: NFTTermsContractContract;
     let tokenTransferProxy: TokenTransferProxyContract;
 
     let orderFactory: DebtOrderFactory;
@@ -64,7 +59,6 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
     const UNDERWRITER = ACCOUNTS[5];
     const RELAYER = ACCOUNTS[6];
 
-    const EXAMPLE_NFT_ID = new BigNumber(13);
     const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
 
     const TX_DEFAULTS = { from: CONTRACT_OWNER, gas: 4000000 };
@@ -74,7 +68,6 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
         const dummyREPTokenAddress = await dummyTokenRegistryContract.getTokenAddress.callAsync("REP");
 
         principalToken = await DummyTokenContract.at(dummyREPTokenAddress, web3, TX_DEFAULTS);
-        principalNFT = await MintableNonFungibleTokenContract.deployed(web3, TX_DEFAULTS);
 
         kernel = await DebtKernelContract.deployed(web3, TX_DEFAULTS);
         debtToken = await DebtTokenContract.deployed(web3, TX_DEFAULTS);
@@ -95,11 +88,6 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
             principalToken.address,
             repaymentRouterTruffle.address,
         );
-        const termsContractNftTruffle = await nftTermsContract.new(
-            debtRegistry.address,
-            principalNFT.address,
-            repaymentRouterTruffle.address,
-        );
 
         // The typings we use ingest vanilla Web3 contracts, so we convert the
         // contract instance deployed by truffle into a Web3 contract instance
@@ -107,12 +95,9 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
             web3.eth.contract(repaymentRouterTruffle.abi).at(repaymentRouterTruffle.address);
         const termsContractWeb3Contract =
             web3.eth.contract(simpleInterestTermsContract.abi).at(termsContractTruffle.address);
-        const termsContractNftWeb3Contract =
-            web3.eth.contract(nftTermsContract.abi).at(termsContractNftTruffle.address);
 
         router = new RepaymentRouterContract(repaymentRouterWeb3Contract, TX_DEFAULTS);
         termsContract = new SimpleInterestTermsContractContract(termsContractWeb3Contract, TX_DEFAULTS);
-        termsContractNFT = new NFTTermsContractContract(termsContractNftWeb3Contract, TX_DEFAULTS);
 
         await tokenTransferProxy.addAuthorizedTransferAgent.sendTransactionAsync(router.address);
 

--- a/test/ts/logs/repayment_router.ts
+++ b/test/ts/logs/repayment_router.ts
@@ -27,27 +27,6 @@ export function LogRepayment(
     };
 }
 
-export function LogNFTRepayment(
-    contract: Address,
-    agreementId: Bytes32,
-    payer: Address,
-    beneficiary: Address,
-    tokenId: UInt,
-    token: Address,
-): ABIDecoder.DecodedLog {
-    return {
-        address: contract,
-        events: LogUtils.getParams([
-            ["_agreementId", agreementId],
-            ["_payer", payer],
-            ["_beneficiary", beneficiary],
-            ["_tokenId", tokenId],
-            ["_token", token],
-        ]),
-        name: "LogNFTRepayment",
-    };
-}
-
 export function LogError(
     contract: Address,
     errorId: UInt,

--- a/test/ts/unit/repayment_router.ts
+++ b/test/ts/unit/repayment_router.ts
@@ -19,7 +19,7 @@ import {BigNumberSetup} from "../test_utils/bignumber_setup";
 import ChaiSetup from "../test_utils/chai_setup";
 import {INVALID_OPCODE, REVERT_ERROR} from "../test_utils/constants";
 
-import {LogError, LogNFTRepayment, LogRepayment} from "../logs/repayment_router";
+import {LogError, LogRepayment} from "../logs/repayment_router";
 
 // Set up Chai
 ChaiSetup.configure();

--- a/test/ts/unit/token_transfer_proxy.ts
+++ b/test/ts/unit/token_transfer_proxy.ts
@@ -13,7 +13,7 @@ import {BigNumberSetup} from "../test_utils/bignumber_setup";
 import ChaiSetup from "../test_utils/chai_setup";
 import {INVALID_OPCODE, REVERT_ERROR} from "../test_utils/constants";
 
-import {LogError, LogNFTRepayment, LogRepayment} from "../logs/repayment_router";
+import {LogError, LogRepayment} from "../logs/repayment_router";
 
 // Set up Chai
 ChaiSetup.configure();


### PR DESCRIPTION
- Fix tests
- Address compiler warnings
- rename `getValueRepaid` to `getValueRepaidToDate`
- Delete `LogNFTRepayment` event
- `SimpleInterestTermsContract` should explicitly adopt `TermsContract` interface