### PR TITLE
Protect `getExpectedRepaymentValue` with modifier

### DIFF
--- a/contracts/examples/SimpleInterestTermsContract.sol
+++ b/contracts/examples/SimpleInterestTermsContract.sol
@@ -57,6 +57,12 @@ contract SimpleInterestTermsContract is TermsContract {
       _;
     }
 
+    modifier onlyThisContract(bytes32 agreementId) {
+        address _contract = debtRegistry.getTermsContract(agreementId);
+        require(address(this) == _contract);
+        _;
+    }
+
     function SimpleInterestTermsContract(
         address _debtRegistry,
         address _repaymentToken,

--- a/contracts/examples/SimpleInterestTermsContract.sol
+++ b/contracts/examples/SimpleInterestTermsContract.sol
@@ -116,6 +116,7 @@ contract SimpleInterestTermsContract is TermsContract {
     )
         public
         view
+        onlyThisContract(agreementId)
         returns (uint _expectedRepaymentValue)
     {
         SimpleInterestParams memory params = unpackParamsForAgreementID(agreementId);

--- a/test/ts/unit/simple_interest_terms_contract.ts
+++ b/test/ts/unit/simple_interest_terms_contract.ts
@@ -291,8 +291,7 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
         const inputParamsAsHex = hexifyParams(principalPlusInterest,
             amortizationUnitType, termLength);
 
-        it("unpacks valid params", async () => {
-            var outputParams = await termsContract.unpackParametersFromBytes.callAsync(
+        it("correctly unpacks parameters into their respective types given raw byte data", async () => {
             let outputParams = await termsContract.unpackParametersFromBytes.callAsync(
               inputParamsAsHex
             );

--- a/test/ts/unit/simple_interest_terms_contract.ts
+++ b/test/ts/unit/simple_interest_terms_contract.ts
@@ -308,7 +308,7 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
             before(async () => {
                 await mockRegistry.mockGetTermsContractReturnValueFor.sendTransactionAsync(
                     ARBITRARY_AGREEMENT_ID,
-                    ATTACKER // this is an attacker's address and thus should result in a revert.
+                    ATTACKER // this is an attacker's address and not the contract's address.
                 );
             });
 

--- a/test/ts/unit/simple_interest_terms_contract.ts
+++ b/test/ts/unit/simple_interest_terms_contract.ts
@@ -293,6 +293,7 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
 
         it("unpacks valid params", async () => {
             var outputParams = await termsContract.unpackParametersFromBytes.callAsync(
+            let outputParams = await termsContract.unpackParametersFromBytes.callAsync(
               inputParamsAsHex
             );
             expect(outputParams[0]).to.bignumber.equal(principalPlusInterest);


### PR DESCRIPTION
- Modifier ensures that the contract mapped to the agreement id passed to `getExpectedRepaymentValue` is also the actual contract executing the code.