### PR TITLE
Add #registerTermStart hook to Terms Contract

### DIFF
--- a/contracts/DebtKernel.sol
+++ b/contracts/DebtKernel.sol
@@ -19,6 +19,7 @@
 pragma solidity 0.4.18;
 
 import "./DebtToken.sol";
+import "./TermsContract.sol";
 import "./TokenTransferProxy.sol";
 import "zeppelin-solidity/contracts/lifecycle/Pausable.sol";
 import "zeppelin-solidity/contracts/math/SafeMath.sol";
@@ -178,6 +179,12 @@ contract DebtKernel is Pausable {
 
         // Mint debt token and finalize debt agreement
         issueDebtAgreement(creditor, debtOrder.issuance);
+
+        // Register debt agreement's start with terms contract
+        require(
+            TermsContract(debtOrder.issuance.termsContract)
+                .registerTermStart(debtOrder.issuance.issuanceHash)
+        );
 
         // Transfer principal to debtor
         if (debtOrder.principalAmount > 0) {

--- a/contracts/TermsContract.sol
+++ b/contracts/TermsContract.sol
@@ -20,6 +20,23 @@ pragma solidity 0.4.18;
 
 
 interface TermsContract {
+     /// When called, the registerTermStart function registers the fact that
+     ///    the debt agreement has begun.  This method is called as a hook by the
+     ///    DebtKernel when a debt order associated with `agreementId` is filled.
+     ///    Method is not required to make any sort of internal state change
+     ///    upon the debt agreement's start, but MUST return `true` in order to
+     ///    acknowledge receipt of the transaction.  If, for any reason, the
+     ///    debt agreement stored at `agreementId` is incompatible with this contract,
+     ///    MUST return `false`, which will cause the pertinent order fill to fail.
+     ///    If this method is called for a debt agreement whose term has already begun,
+     ///    must THROW.  Similarly, if this method is called by any contract other
+     ///    than the current DebtKernel, must THROW.
+     /// @param  agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
+     /// @return _success bool. Acknowledgment of whether
+    function registerTermStart(
+        bytes32 agreementId
+    ) public returns (bool _success);
+
      /// When called, the registerRepayment function records the debtor's
      ///  repayment, as well as any auxiliary metadata needed by the contract
      ///  to determine ex post facto the value repaid (e.g. current USD

--- a/contracts/examples/SimpleInterestTermsContract.sol
+++ b/contracts/examples/SimpleInterestTermsContract.sol
@@ -46,6 +46,7 @@ contract SimpleInterestTermsContract is TermsContract {
 
     DebtRegistry public debtRegistry;
 
+    address public debtKernel;
     address public repaymentToken;
     address public repaymentRouter;
 
@@ -59,8 +60,14 @@ contract SimpleInterestTermsContract is TermsContract {
         _;
     }
 
+    modifier onlyDebtKernel() {
+        require(msg.sender == debtKernel);
+        _;
+    }
+
     function SimpleInterestTermsContract(
         address _debtRegistry,
+        address _debtKernel,
         address _repaymentToken,
         address _repaymentRouter
     )
@@ -68,8 +75,26 @@ contract SimpleInterestTermsContract is TermsContract {
     {
         debtRegistry = DebtRegistry(_debtRegistry);
 
+        debtKernel = _debtKernel;
         repaymentToken = _repaymentToken;
         repaymentRouter = _repaymentRouter;
+    }
+
+    /// When called, the registerTermStart function registers the fact that
+    ///    the debt agreement has begun.  Given that the SimpleInterestTermsContract
+    ///    doesn't rely on taking any sorts of actions when the loan term begins,
+    ///    we simply validate DebtKernel is the transaction sender, and return
+    ///    `true` if the debt agreement is associated with this terms contract.
+    /// @param  agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
+    /// @return _success bool. Acknowledgment of whether
+    function registerTermStart(
+        bytes32 agreementId
+    )
+        public
+        onlyDebtKernel
+        returns (bool _success)
+    {
+        return debtRegistry.getTermsContract(agreementId) == address(this);
     }
 
      /// When called, the registerRepayment function records the debtor's

--- a/contracts/examples/TermsContractRegistry.sol
+++ b/contracts/examples/TermsContractRegistry.sol
@@ -28,4 +28,29 @@ contract TermsContractRegistry {
             "SimpleInterestTermsContract"
         )];
     }
+
+    function setCompoundInterestTermsContractAddress(
+        address tokenAddress,
+        address termsContract
+    )
+        public
+    {
+        symbolToTermsContractAddress[keccak256(
+            tokenAddress,
+            "CompoundInterestTermsContract"
+        )] = termsContract;
+    }
+
+    function getCompoundInterestTermsContractAddress(
+        address tokenAddress
+    )
+        public
+        view
+        returns (address)
+    {
+        return symbolToTermsContractAddress[keccak256(
+            tokenAddress,
+            "CompoundInterestTermsContract"
+        )];
+    }
 }

--- a/contracts/test/mocks/MockTermsContract.sol
+++ b/contracts/test/mocks/MockTermsContract.sol
@@ -69,57 +69,35 @@ contract MockTermsContract is MockContract {
         ));
     }
 
-    function registerNFTRepayment(
-        bytes32 agreementId,
-        address payer,
-        address beneficiary,
-        uint tokenId,
-        address tokenAddress
+    function registerTermStart(
+        bytes32 agreementId
     )
         public
-        returns (bool _success)
+        returns (bool _registered)
     {
-        functionCalledWithArgs("registerNFTRepayment", keccak256(
-            agreementId,
-            payer,
-            beneficiary,
-            tokenId,
-            tokenAddress
-        ));
+        functionCalledWithArgs("registerTermStart", agreementId);
 
-        return getMockReturnValue("registerNFTRepayment", DEFAULT_SIGNATURE_ARGS) == bytes32(1);
+        return getMockReturnValue("registerTermStart", agreementId) == bytes32(1);
     }
 
-    function mockRegisterNFTRepaymentReturnValue(bool success)
+    function mockRegisterTermStartReturnValue(bytes32 agreementId, bool success)
         public
     {
-        mockReturnValue("registerNFTRepayment", DEFAULT_SIGNATURE_ARGS, success ? bytes32(1) : bytes32(0));
+        mockReturnValue("registerTermStart", agreementId, success ? bytes32(1) : bytes32(0));
     }
 
-    function wasRegisterNFTRepaymentCalledWith(
-        bytes32 agreementId,
-        address payer,
-        address beneficiary,
-        uint tokenId,
-        address tokenAddress
-    )
+    function wasRegisterTermStartCalledWith(bytes32 agreementId)
         public
         view
-        returns (bool wasCalled)
+        returns (bool _wasCalled)
     {
-        return wasFunctionCalledWithArgs("registerNFTRepayment", keccak256(
-            agreementId,
-            payer,
-            beneficiary,
-            tokenId,
-            tokenAddress
-        ));
+        return wasFunctionCalledWithArgs("registerTermStart", agreementId);
     }
 
     function getFunctionList()
         internal
         returns (string[10] functionNames)
     {
-        return ["registerRepayment", "registerNFTRepayment", "", "", "", "", "", "", "", ""];
+        return ["registerRepayment", "registerTermStart", "", "", "", "", "", "", "", ""];
     }
 }

--- a/contracts/test/terms_contracts/DummyCollateralizedContract.sol
+++ b/contracts/test/terms_contracts/DummyCollateralizedContract.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.18;
 
 import "zeppelin-solidity/contracts/math/SafeMath.sol";
 
-import "../examples/Collateralized.sol";
+import "../../examples/Collateralized.sol";
 
 
 contract DummyCollateralizedContract is Collateralized {
@@ -14,6 +14,12 @@ contract DummyCollateralizedContract is Collateralized {
     function DummyCollateralizedContract(address _debtRegistry) public Collateralized(_debtRegistry) {}
 
     /* Naive `TermsContract` interface implementation. */
+
+    function registerTermStart(
+        bytes32 agreementId
+    ) public returns (bool _success) {
+        return true;
+    }
 
     function registerRepayment(
         bytes32 agreementId,

--- a/contracts/test/terms_contracts/IncompatibleTermsContract.sol
+++ b/contracts/test/terms_contracts/IncompatibleTermsContract.sol
@@ -1,0 +1,97 @@
+/*
+
+  Copyright 2017 Dharma Labs Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
+
+pragma solidity 0.4.18;
+
+import "../../TermsContract.sol";
+
+
+/**
+ * Contract created for testing purposes that will consistently reject
+ * debt order fills that are mapped to it by returning `false` for
+ * `registerTermStart`
+ *
+ * Author: Nadav Hollander Github: nadavhollander
+ */
+contract IncompatibleTermsContract is TermsContract {
+    /// When called, the registerTermStart function registers the fact that
+    ///    the debt agreement has begun.  Given that the SimpleInterestTermsContract
+    ///    doesn't rely on taking any sorts of actions when the loan term begins,
+    ///    we simply validate DebtKernel is the transaction sender, and return
+    ///    `true` if the debt agreement is associated with this terms contract.
+    /// @param  agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
+    /// @return _success bool. Acknowledgment of whether
+    function registerTermStart(
+        bytes32 agreementId
+    )
+        public
+        returns (bool _success)
+    {
+        return false;
+    }
+
+     /// When called, the registerRepayment function records the debtor's
+     ///  repayment, as well as any auxiliary metadata needed by the contract
+     ///  to determine ex post facto the value repaid (e.g. current USD
+     ///  exchange rate)
+     /// @param  agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
+     /// @param  payer address. The address of the payer.
+     /// @param  beneficiary address. The address of the payment's beneficiary.
+     /// @param  unitsOfRepayment uint. The units-of-value repaid in the transaction.
+     /// @param  tokenAddress address. The address of the token with which the repayment transaction was executed.
+    function registerRepayment(
+        bytes32 agreementId,
+        address payer,
+        address beneficiary,
+        uint256 unitsOfRepayment,
+        address tokenAddress
+    )
+        public
+        returns (bool _success)
+    {
+        return false;
+    }
+
+     /// Returns the cumulative units-of-value expected to be repaid given a block's timestamp.
+     ///  Note this is not a constant function -- this value can vary on basis of any number of
+     ///  conditions (e.g. interest rates can be renegotiated if repayments are delinquent).
+     /// @param  agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
+     /// @param  timestamp uint. The timestamp for which repayment expectation is being queried.
+     /// @return uint256 The cumulative units-of-value expected to be repaid given a block's timestamp.
+    function getExpectedRepaymentValue(
+        bytes32 agreementId,
+        uint256 timestamp
+    )
+        public
+        view
+        returns (uint _expectedRepaymentValue)
+    {
+        return 0;
+    }
+
+     /// Returns the cumulative units-of-value repaid to date.
+     /// @param agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
+     /// @return uint256 The cumulative units-of-value repaid by the specified block timestamp.
+    function getValueRepaidToDate(bytes32 agreementId)
+        public
+        view
+        returns (uint _valueRepaid)
+    {
+        return 0;
+    }
+}

--- a/migrations/4_deploy_terms_contracts.js
+++ b/migrations/4_deploy_terms_contracts.js
@@ -1,19 +1,25 @@
 module.exports = (deployer, network, accounts) => {
     const DebtRegistry = artifacts.require("DebtRegistry");
+    const DebtKernel = artifacts.require("DebtKernel");
     const RepaymentRouter = artifacts.require("RepaymentRouter");
     const TermsContractRegistry = artifacts.require("TermsContractRegistry");
     const TokenRegistry = artifacts.require("TokenRegistry");
     const SimpleInterestTermsContract = artifacts.require("SimpleInterestTermsContract");
+    const CompoundInterestTermsContract = artifacts.require("CompoundInterestTermsContract");
+    const IncompatibleTermsContract = artifacts.require("IncompatibleTermsContract");
 
     const TX_DEFAULTS = { from: accounts[0], gas: 4000000 };
 
+    deployer.deploy(IncompatibleTermsContract);
     deployer.deploy(TermsContractRegistry).then(async () => {
         const debtRegistry = await DebtRegistry.deployed(web3);
+        const debtKernel = await DebtKernel.deployed(web3);
         const repaymentRouter = await RepaymentRouter.deployed(web3);
 
         const termsContractRegistry = await TermsContractRegistry.at(TermsContractRegistry.address);
 
-        let addressToTermsContractAddress = {};
+        let simpleInterestTermsContracts = {};
+        let compoundInterestTermsContracts = {};
 
         if (network !== "live") {
             const tokenRegistry = await TokenRegistry.deployed(web3);
@@ -22,35 +28,93 @@ module.exports = (deployer, network, accounts) => {
             const dummyMKRTokenAddress = await tokenRegistry.getTokenAddress("MKR");
             const dummyZRXTokenAddress = await tokenRegistry.getTokenAddress("ZRX");
 
+            /*
+             * Deploy SimpleInterestTermsContract's for each token type.
+             */
+
             const simpleInterestREPTermsContract = await SimpleInterestTermsContract.new(
                 debtRegistry.address,
+                debtKernel.address,
                 dummyREPTokenAddress,
                 repaymentRouter.address,
             );
 
             const simpleInterestMKRTermsContract = await SimpleInterestTermsContract.new(
                 debtRegistry.address,
+                debtKernel.address,
                 dummyMKRTokenAddress,
                 repaymentRouter.address,
             );
 
             const simpleInterestZRXTermsContract = await SimpleInterestTermsContract.new(
                 debtRegistry.address,
+                debtKernel.address,
                 dummyZRXTokenAddress,
                 repaymentRouter.address,
             );
 
-            addressToTermsContractAddress[dummyREPTokenAddress] = simpleInterestREPTermsContract.address;
-            addressToTermsContractAddress[dummyMKRTokenAddress] = simpleInterestMKRTermsContract.address;
-            addressToTermsContractAddress[dummyZRXTokenAddress] = simpleInterestZRXTermsContract.address;
+            /*
+             * Deploy CompoundInterestTermsContract's for each token type.
+             */
+
+            const compoundInterestREPTermsContract = await CompoundInterestTermsContract.new(
+                debtRegistry.address,
+                debtKernel.address,
+                dummyREPTokenAddress,
+                repaymentRouter.address,
+            );
+
+            const compoundInterestMKRTermsContract = await CompoundInterestTermsContract.new(
+                debtRegistry.address,
+                debtKernel.address,
+                dummyMKRTokenAddress,
+                repaymentRouter.address,
+            );
+
+            const compoundInterestZRXTermsContract = await CompoundInterestTermsContract.new(
+                debtRegistry.address,
+                debtKernel.address,
+                dummyZRXTokenAddress,
+                repaymentRouter.address,
+            );
+
+            simpleInterestTermsContracts[dummyREPTokenAddress] =
+                simpleInterestREPTermsContract.address;
+            simpleInterestTermsContracts[dummyMKRTokenAddress] =
+                simpleInterestMKRTermsContract.address;
+            simpleInterestTermsContracts[dummyZRXTokenAddress] =
+                simpleInterestZRXTermsContract.address;
+
+            compoundInterestTermsContracts[dummyREPTokenAddress] =
+                compoundInterestREPTermsContract.address;
+            compoundInterestTermsContracts[dummyMKRTokenAddress] =
+                compoundInterestMKRTermsContract.address;
+            compoundInterestTermsContracts[dummyZRXTokenAddress] =
+                compoundInterestZRXTermsContract.address;
         } else {
             // TODO fill in mainnet implementation
         }
 
-        for (const address in addressToTermsContractAddress) {
-            if (addressToTermsContractAddress.hasOwnProperty(address)) {
+        /*
+         * Register simple interest terms contracts to TermsContractRegistry
+         */
+        for (const address in simpleInterestTermsContracts) {
+            if (simpleInterestTermsContracts.hasOwnProperty(address)) {
                 await termsContractRegistry.setSimpleInterestTermsContractAddress(
-                    address, addressToTermsContractAddress[address],
+                    address,
+                    simpleInterestTermsContracts[address],
+                );
+            }
+        }
+
+        /*
+         * Register compound interest terms contracts to TermsContractRegistry
+         */
+        for (const address in compoundInterestTermsContracts) {
+            if (compoundInterestTermsContracts.hasOwnProperty(address)) {
+                await termsContractRegistry.setCompoundInterestTermsContractAddress(
+                    address,
+                    compoundInterestTermsContracts[address],
                 );
             }
         }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "soltsice": "soltsice",
     "migrate": "npm run transpile; truffle migrate",
     "prettify": "prettier --write test/ts/**/*.ts types/**/*.ts types/*.ts",
-    "test": "npm run compile; npm run generate-typings; npm run migrate; truffle test transpiled/test/ts/unit/debt_kernel.js",
+    "test": "npm run compile; npm run generate-typings; npm run migrate; truffle test",
     "chain": "ganache-cli --networkId 70 --accounts 20",
     "validate": "npm ls"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "soltsice": "soltsice",
     "migrate": "npm run transpile; truffle migrate",
     "prettify": "prettier --write test/ts/**/*.ts types/**/*.ts types/*.ts",
-    "test": "npm run compile; npm run generate-typings; npm run migrate; truffle test",
+    "test": "npm run compile; npm run generate-typings; npm run migrate; truffle test transpiled/test/ts/unit/debt_kernel.js",
     "chain": "ganache-cli --networkId 70 --accounts 20",
     "validate": "npm ls"
   },

--- a/test/ts/integration/debt_kernel.ts
+++ b/test/ts/integration/debt_kernel.ts
@@ -99,11 +99,14 @@ contract("Debt Kernel (Integration Tests)", async (ACCOUNTS) => {
 
         dummyREPToken = await DummyTokenContract.at(dummyREPTokenAddress, web3, TX_DEFAULTS);
 
-        simpleInterestTermsContractAddress = await termsContractRegistryContract
-            .getSimpleInterestTermsContractAddress
-            .callAsync(dummyREPTokenAddress);
+        simpleInterestTermsContractAddress = await termsContractRegistryContract.getSimpleInterestTermsContractAddress.callAsync(
+            dummyREPTokenAddress,
+        );
 
-        const incompatibleTermsContract = await IncompatibleTermsContractContract.deployed(web3, TX_DEFAULTS);
+        const incompatibleTermsContract = await IncompatibleTermsContractContract.deployed(
+            web3,
+            TX_DEFAULTS,
+        );
         incompatibleTermsContractAddress = incompatibleTermsContract.address;
 
         debtTokenContract = await DebtTokenContract.deployed(web3, TX_DEFAULTS);
@@ -879,7 +882,6 @@ contract("Debt Kernel (Integration Tests)", async (ACCOUNTS) => {
                     debtOrder = await orderFactory.generateDebtOrder({
                         termsContract: incompatibleTermsContractAddress,
                     });
-
                 });
 
                 it("should throw", async () => {

--- a/test/ts/integration/repayment_router.ts
+++ b/test/ts/integration/repayment_router.ts
@@ -96,6 +96,7 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
         );
         const termsContractTruffle = await simpleInterestTermsContract.new(
             debtRegistry.address,
+            kernel.address,
             principalToken.address,
             repaymentRouterTruffle.address,
         );

--- a/test/ts/unit/compound_interest_terms_contract.ts
+++ b/test/ts/unit/compound_interest_terms_contract.ts
@@ -56,7 +56,8 @@ contract("CompoundInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
     const CONTRACT_OWNER = ACCOUNTS[0];
     const PAYER = ACCOUNTS[1];
     const BENEFICIARY = ACCOUNTS[2];
-    const ATTACKER = ACCOUNTS[3];
+    const MOCK_DEBT_KERNEL_ADDRESS = ACCOUNTS[3];
+    const ATTACKER = ACCOUNTS[4];
 
     const TERMS_CONTRACT_PARAMETERS = web3.sha3(
         "any 32 byte hex value can represent the terms contract's parameters",
@@ -118,6 +119,7 @@ contract("CompoundInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
 
         const termsContractTruffle = await compoundInterestTermsContract.new(
             mockRegistry.address,
+            MOCK_DEBT_KERNEL_ADDRESS,
             mockToken.address,
             repaymentRouterTruffle.address,
         );
@@ -164,6 +166,31 @@ contract("CompoundInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
             await expect(termsContract.repaymentToken.callAsync()).to.eventually.equal(
                 mockToken.address,
             );
+        });
+    });
+
+    // #registerTermStart in SimpleInterestTermsContract is a no-op function that simply
+    //  returns true if the DebtKernel is its caller.  This is because the simpleInterestTermsContract
+    //  need not take any action at the loan term's start.
+    describe("#registerTermStart", async () => {
+        describe("agent who is not DebtKernel calls registerTermStart", () => {
+            it("should throw", async () => {
+                await expect(
+                    termsContract.registerTermStart.sendTransactionAsync(ARBITRARY_AGREEMENT_ID, {
+                        from: ATTACKER,
+                    }),
+                ).to.eventually.be.rejectedWith(REVERT_ERROR);
+            });
+        });
+
+        describe("agent who is DebtKernel calls registerTermStart", () => {
+            it("should not throw", async () => {
+                await expect(
+                    termsContract.registerTermStart.sendTransactionAsync(ARBITRARY_AGREEMENT_ID, {
+                        from: MOCK_DEBT_KERNEL_ADDRESS,
+                    }),
+                ).to.eventually.be.fulfilled;
+            });
         });
     });
 

--- a/test/ts/unit/debt_kernel.ts
+++ b/test/ts/unit/debt_kernel.ts
@@ -19,6 +19,7 @@ import { DebtKernelContract } from "../../../types/generated/debt_kernel";
 import { MockDebtTokenContract } from "../../../types/generated/mock_debt_token";
 import { MockERC20TokenContract } from "../../../types/generated/mock_e_r_c20_token";
 import { MockTokenTransferProxyContract } from "../../../types/generated/mock_token_transfer_proxy";
+import { MockTermsContractContract } from "../../../types/generated/mock_terms_contract";
 import { RepaymentRouterContract } from "../../../types/generated/repayment_router";
 
 import { DebtKernelErrorCodes } from "../../../types/errors";
@@ -45,6 +46,7 @@ const expect = chai.expect;
 
 const debtKernelContract = artifacts.require("DebtKernel");
 const mockDebtTokenContract = artifacts.require("MockDebtToken");
+const mockTermsContractArtifacts = artifacts.require("MockTermsContract");
 
 contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
     let kernel: DebtKernelContract;
@@ -52,6 +54,7 @@ contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
     let mockDebtToken: MockDebtTokenContract;
     let mockPrincipalToken: MockERC20TokenContract;
     let mockTokenTransferProxy: MockTokenTransferProxyContract;
+    let mockTermsContract: MockTermsContractContract;
 
     let orderFactory: DebtOrderFactory;
     let defaultOrderParams: { [key: string]: any };
@@ -71,9 +74,8 @@ contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
 
     const UNDERWRITER = ACCOUNTS[11];
     const RELAYER = ACCOUNTS[12];
-    const TERMS_CONTRACT = ACCOUNTS[13];
-    const MALICIOUS_TERMS_CONTRACTS = ACCOUNTS[14];
-    const MALICIOUS_EXCHANGE_CONTRACT = ACCOUNTS[15];
+
+    const MALICIOUS_TERMS_CONTRACTS = ACCOUNTS[13];
 
     const TERMS_CONTRACT_PARAMETERS = web3.sha3("arbitrary terms contract parameters");
 
@@ -84,15 +86,38 @@ contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
     const reset = async () => {
         mockTokenTransferProxy = await MockTokenTransferProxyContract.deployed(web3, TX_DEFAULTS);
 
-        const kernelContractInstance = await debtKernelContract.new(mockTokenTransferProxy.address);
+        /*
+        In our test environment, we want to interact with the contract being
+        unit tested as a statically-typed entity. In order to accomplish this,
+        we take the following steps:
 
-        // The typings we use ingest vanilla Web3 contracts, so we convert the
-        // contract instance deployed by truffle into a Web3 contract instance
-        const web3ContractInstance = web3.eth
+          1 - Instantiate an instance of the contract through the Truffle
+              framework.
+          2 - Instantiate an instance of the contract through the Web3 API using
+              the truffle instance's ABI.
+          3 - Use the Web3 contract instance to instantiate a statically-typed
+              version of the contract as handled by ABI-GEN, which generates
+              a contract wrapper with types pulled from the contract's ABI.
+         */
+
+        // Step 1: Instantiate a truffle instance of the contract.
+        const kernelContractInstance = await debtKernelContract.new(mockTokenTransferProxy.address);
+        const mockTermsContractInstance = await mockTermsContractArtifacts.new();
+
+        // Step 2: Instantiate a web3 instance of the contract.
+        const kernelWeb3ContractInstance = web3.eth
             .contract(debtKernelContract.abi)
             .at(kernelContractInstance.address);
+        const mockTermsContractWeb3ContractInstance = web3.eth
+            .contract(mockTermsContractArtifacts.abi)
+            .at(mockTermsContractInstance.address);
 
-        kernel = new DebtKernelContract(web3ContractInstance, TX_DEFAULTS);
+        // Step 3: Instantiate a statically-typed version of the contract.
+        kernel = new DebtKernelContract(kernelWeb3ContractInstance, TX_DEFAULTS);
+        mockTermsContract = new MockTermsContractContract(
+            mockTermsContractWeb3ContractInstance,
+            TX_DEFAULTS,
+        );
 
         // Load current Repayment Router for use as a version address in the Issuance
         // commitments
@@ -120,7 +145,7 @@ contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
             principalTokenAddress: mockPrincipalToken.address,
             relayer: RELAYER,
             relayerFee: Units.ether(0.0015),
-            termsContract: TERMS_CONTRACT,
+            termsContract: mockTermsContract.address,
             termsContractParameters: TERMS_CONTRACT_PARAMETERS,
             underwriter: UNDERWRITER,
             underwriterFee: Units.ether(0.0015),
@@ -215,6 +240,11 @@ contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
                         debtOrder.getCreditor(),
                         mockTokenTransferProxy.address,
                         debtOrder.getPrincipalAmount().plus(debtOrder.getCreditorFee()),
+                    );
+
+                    await mockTermsContract.mockRegisterTermStartReturnValue.sendTransactionAsync(
+                        debtOrder.getIssuanceCommitment().getHash(),
+                        true,
                     );
 
                     const txHash = await kernel.fillDebtOrder.sendTransactionAsync(
@@ -681,6 +711,48 @@ contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
                     );
                 });
             });
+
+            describe("...when terms contract returns false for `registerTermStart`", () => {
+                before(async () => {
+                    await resetMocks();
+
+                    debtOrder = await orderFactory.generateDebtOrder();
+
+                    await mockDebtToken.mockCreateReturnValue.sendTransactionAsync(
+                        new BigNumber(debtOrder.getIssuanceCommitment().getHash()),
+                    );
+
+                    await mockPrincipalToken.mockBalanceOfFor.sendTransactionAsync(
+                        debtOrder.getCreditor(),
+                        debtOrder.getPrincipalAmount().plus(debtOrder.getCreditorFee()),
+                    );
+                    await mockPrincipalToken.mockAllowanceFor.sendTransactionAsync(
+                        debtOrder.getCreditor(),
+                        mockTokenTransferProxy.address,
+                        debtOrder.getPrincipalAmount().plus(debtOrder.getCreditorFee()),
+                    );
+
+                    await mockTermsContract.mockRegisterTermStartReturnValue.sendTransactionAsync(
+                        debtOrder.getIssuanceCommitment().getHash(),
+                        false,
+                    );
+                });
+
+                it("should throw", async () => {
+                    await expect(
+                        kernel.fillDebtOrder.sendTransactionAsync(
+                            debtOrder.getCreditor(),
+                            debtOrder.getOrderAddresses(),
+                            debtOrder.getOrderValues(),
+                            debtOrder.getOrderBytes32(),
+                            debtOrder.getSignaturesV(),
+                            debtOrder.getSignaturesR(),
+                            debtOrder.getSignaturesS(),
+                            { from: debtOrder.getCreditor() },
+                        ),
+                    ).to.eventually.be.rejectedWith(REVERT_ERROR);
+                });
+            });
         });
 
         describe("User fills valid, nonconsensual debt order", () => {
@@ -842,49 +914,6 @@ contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
                             signaturesS,
                             signaturesV,
                         ] = await getMismatchedSignatures(order, order, mismatchedOrder);
-                        await testShouldReturnError(
-                            order,
-                            DebtKernelErrorCodes.ORDER_INVALID_NON_CONSENSUAL,
-                            signaturesR,
-                            signaturesS,
-                            signaturesV,
-                        );
-                    });
-                });
-            });
-
-            describe("...with mismatched 0x exchange contract", () => {
-                before(async () => {
-                    mismatchedOrder = await orderFactory.generateDebtOrder({
-                        salt: order.getIssuanceCommitment().getSalt(),
-                        zeroExExchangeContract: MALICIOUS_EXCHANGE_CONTRACT,
-                    });
-                });
-
-                describe("creditor's signature commits to 0x exchange contract =/= order's", async () => {
-                    it("should return ORDER_INVALID_NON_CONSENSUAL error", async () => {
-                        const [
-                            signaturesR,
-                            signaturesS,
-                            signaturesV,
-                        ] = await getMismatchedSignatures(order, mismatchedOrder, order);
-                        await testShouldReturnError(
-                            order,
-                            DebtKernelErrorCodes.ORDER_INVALID_NON_CONSENSUAL,
-                            signaturesR,
-                            signaturesS,
-                            signaturesV,
-                        );
-                    });
-                });
-
-                describe("debtor's signature commits to 0x exchange contract =/= order's", async () => {
-                    it("should return ORDER_INVALID_NON_CONSENSUAL error", async () => {
-                        const [
-                            signaturesR,
-                            signaturesS,
-                            signaturesV,
-                        ] = await getMismatchedSignatures(mismatchedOrder, order, order);
                         await testShouldReturnError(
                             order,
                             DebtKernelErrorCodes.ORDER_INVALID_NON_CONSENSUAL,

--- a/test/ts/unit/debt_kernel.ts
+++ b/test/ts/unit/debt_kernel.ts
@@ -242,6 +242,7 @@ contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
                         debtOrder.getPrincipalAmount().plus(debtOrder.getCreditorFee()),
                     );
 
+                    await mockTermsContract.reset.sendTransactionAsync();
                     await mockTermsContract.mockRegisterTermStartReturnValue.sendTransactionAsync(
                         debtOrder.getIssuanceCommitment().getHash(),
                         true,
@@ -329,6 +330,14 @@ contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
                             debtOrder.getRelayerFee(),
                         ),
                     );
+                });
+
+                it("should register term start with terms contract", async () => {
+                    await expect(
+                        mockTermsContract.wasRegisterTermStartCalledWith.callAsync(
+                            debtOrder.getIssuanceCommitment().getHash(),
+                        ),
+                    ).to.eventually.be.true;
                 });
             };
         };

--- a/test/ts/unit/simple_interest_terms_contract.ts
+++ b/test/ts/unit/simple_interest_terms_contract.ts
@@ -39,7 +39,7 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
     const CONTRACT_OWNER = ACCOUNTS[0];
     const PAYER = ACCOUNTS[1];
     const BENEFICIARY = ACCOUNTS[2];
-    const DEBT_KERNEL_ADDRESS = ACCOUNTS[3];
+    const MOCK_DEBT_KERNEL_ADDRESS = ACCOUNTS[3];
     const ATTACKER = ACCOUNTS[4];
 
     const TERMS_CONTRACT_PARAMETERS = web3.sha3(
@@ -80,7 +80,7 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
 
         const termsContractTruffle = await simpleInterestTermsContract.new(
             mockRegistry.address,
-            DEBT_KERNEL_ADDRESS,
+            MOCK_DEBT_KERNEL_ADDRESS,
             mockToken.address,
             repaymentRouterTruffle.address,
         );
@@ -148,7 +148,7 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
             it("should not throw", async () => {
                 await expect(
                     termsContract.registerTermStart.sendTransactionAsync(ARBITRARY_AGREEMENT_ID, {
-                        from: DEBT_KERNEL_ADDRESS,
+                        from: MOCK_DEBT_KERNEL_ADDRESS,
                     }),
                 ).to.eventually.be.fulfilled;
             });


### PR DESCRIPTION
There are many cases in which terms contracts will want to execute some sort of logic when the debt agreement is filled.  For example, a collateral-holding terms contract could pull collateral from a debtor _only once_ the debt order is filled, meaning debtors will be able to sign and broadcast collateralized debt orders without having to lock up their assets for an arbitrary period beforehand.

As such, this PR introduces the following:
- add a `#registerTermStart` hook to the the TermsContract interface
- update example terms contracts to include this method
- update DebtKernel to automatically call `#registerTermStart` when issuing debt agreement
- update test suite to cover all of the above.