### PR TITLE
TokenRegistry should store list of tokens it tracks

### DIFF
--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -3,14 +3,57 @@ pragma solidity 0.4.18;
 import "zeppelin-solidity/contracts/ownership/Ownable.sol";
 
 
+/**
+ * The TokenRegistry is a basic registry mapping token symbols
+ * to their known, deployed addresses on the current blockchain.
+ *
+ * Note that the TokenRegistry does *not* mediate any of the
+ * core protocol's business logic, but, rather, is a helpful
+ * utility for Terms Contracts to use in encoding, decoding, and
+ * resolving the addresses of currently deployed tokens.
+ *
+ * At this point in time, administration of the Token Registry is
+ * under Dharma Labs' control.  With more sophisticated decentralized
+ * governance mechanisms, we intend to shift ownership of this utility
+ * contract to the Dharma community.
+ */
 contract TokenRegistry is Ownable {
     mapping (bytes32 => address) public symbolToTokenAddress;
+    bytes32[256] public tokenSymbolHashList;
+    uint8 public tokenSymbolHashListLength;
 
+    /**
+     * Maps the given symbol to the given token address.
+     */
     function setTokenAddress(string symbol, address token) public onlyOwner {
-        symbolToTokenAddress[keccak256(symbol)] = token;
+        require(tokenSymbolHashListLength < 256);
+
+        bytes32 symbolHash = keccak256(symbol);
+
+        if (symbolToTokenAddress[symbolHash] == address(0)) {
+            tokenSymbolHashList[tokenSymbolHashListLength] = symbolHash;
+            tokenSymbolHashListLength++;
+        }
+
+        symbolToTokenAddress[symbolHash] = token;
     }
 
-    function getTokenAddress(string symbol) public view returns (address) {
+    /**
+     * Given a symbol, resolves the current address of the token the symbol is mapped to.
+     */
+    function getTokenAddressBySymbol(string symbol) public view returns (address) {
         return symbolToTokenAddress[keccak256(symbol)];
+    }
+
+    /**
+     * Given the known index of a token within the registry's symbol hash list,
+     * returns the address of the token mapped to the symbol at that index.
+     *
+     * This is a useful utility for compactly encoding the address of a token into a
+     * TermsContractParameters string -- by encoding a token by its index in a
+     * a 256 slot array, we can represent a token by a 1 byte uint instead of a 20 byte address.
+     */
+    function getTokenAddressByIndex(uint index) public view returns (address) {
+        return symbolToTokenAddress[tokenSymbolHashList[index]];
     }
 }

--- a/migrations/4_deploy_terms_contracts.js
+++ b/migrations/4_deploy_terms_contracts.js
@@ -24,9 +24,9 @@ module.exports = (deployer, network, accounts) => {
         if (network !== "live") {
             const tokenRegistry = await TokenRegistry.deployed(web3);
 
-            const dummyREPTokenAddress = await tokenRegistry.getTokenAddress("REP");
-            const dummyMKRTokenAddress = await tokenRegistry.getTokenAddress("MKR");
-            const dummyZRXTokenAddress = await tokenRegistry.getTokenAddress("ZRX");
+            const dummyREPTokenAddress = await tokenRegistry.getTokenAddressBySymbol("REP");
+            const dummyMKRTokenAddress = await tokenRegistry.getTokenAddressBySymbol("MKR");
+            const dummyZRXTokenAddress = await tokenRegistry.getTokenAddressBySymbol("ZRX");
 
             /*
              * Deploy SimpleInterestTermsContract's for each token type.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "compile": "truffle compile",
     "migrate": "truffle migrate",
     "prettify": "prettier --write test/ts/**/*.ts types/**/*.ts types/*.ts artifacts/*.ts",
-    "test": "npm run compile; npm run generate-typings; npm run migrate; truffle test",
+    "test": "npm run compile; npm run generate-typings; npm run transpile; npm run migrate; truffle test",
     "chain": "ganache-cli --networkId 70 --accounts 20",
     "validate": "npm ls"
   },

--- a/test/ts/integration/debt_kernel.ts
+++ b/test/ts/integration/debt_kernel.ts
@@ -93,7 +93,7 @@ contract("Debt Kernel (Integration Tests)", async (ACCOUNTS) => {
             TX_DEFAULTS,
         );
 
-        const dummyREPTokenAddress = await dummyTokenRegistryContract.getTokenAddress.callAsync(
+        const dummyREPTokenAddress = await dummyTokenRegistryContract.getTokenAddressBySymbol.callAsync(
             "REP",
         );
 

--- a/test/ts/integration/repayment_router.ts
+++ b/test/ts/integration/repayment_router.ts
@@ -66,7 +66,7 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
 
     before(async () => {
         const dummyTokenRegistryContract = await TokenRegistryContract.deployed(web3, TX_DEFAULTS);
-        const dummyREPTokenAddress = await dummyTokenRegistryContract.getTokenAddress.callAsync(
+        const dummyREPTokenAddress = await dummyTokenRegistryContract.getTokenAddressBySymbol.callAsync(
             "REP",
         );
 

--- a/test/ts/migrations/3_deploy_test_contracts_test.ts
+++ b/test/ts/migrations/3_deploy_test_contracts_test.ts
@@ -103,17 +103,17 @@ contract("Migration #3: Deploying Test Contracts", async (ACCOUNTS) => {
     describe("#TokenRegistry", () => {
         it("should register the address for Augur's REP token", async () => {
             expect(
-                tokenRegistry.getTokenAddress.callAsync(REP_TOKEN_SYMBOL),
+                tokenRegistry.getTokenAddressBySymbol.callAsync(REP_TOKEN_SYMBOL),
             ).to.eventually.not.equal(NULL_ADDRESS);
         });
         it("should register the address for Maker's MKR token", async () => {
             expect(
-                tokenRegistry.getTokenAddress.callAsync(MKR_TOKEN_SYMBOL),
+                tokenRegistry.getTokenAddressBySymbol.callAsync(MKR_TOKEN_SYMBOL),
             ).to.eventually.not.equal(NULL_ADDRESS);
         });
         it("should register the address for 0x's ZRX token", async () => {
             expect(
-                tokenRegistry.getTokenAddress.callAsync(ZRX_TOKEN_SYMBOL),
+                tokenRegistry.getTokenAddressBySymbol.callAsync(ZRX_TOKEN_SYMBOL),
             ).to.eventually.not.equal(NULL_ADDRESS);
         });
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,6 @@
     "node_modules/types-bn/index.d.ts",
     "types/*.ts",
     "test/**/*.ts",
-    "utils/*.ts",
-    "artifacts/*.ts",
-    "artifacts/**/*.ts",
+    "utils/*.ts"
   ]
 }


### PR DESCRIPTION
This PR introduces:

- A `getTokenAddressByIndex` method to the token registry, which returns a token's address given its index in the list of tokens tracked by the registry.  This is useful in allowing us to compactly represent a token in a terms contract parameter string using just its index.
- Some more documentation / minor fixes that enable tests to pass.

