### PR TITLE
Update registerTermStart signature to include debtor address

### DIFF
--- a/contracts/DebtKernel.sol
+++ b/contracts/DebtKernel.sol
@@ -181,6 +181,9 @@ contract DebtKernel is Pausable {
         issueDebtAgreement(creditor, debtOrder.issuance);
 
         // Register debt agreement's start with terms contract
+        // We permit terms contracts to be undefined (for debt agreements which
+        // may not have terms contracts associated with them), and only
+        // register a term's start if the terms contract address is defined.
         if (debtOrder.issuance.termsContract != address(0)) {
             require(
                 TermsContract(debtOrder.issuance.termsContract)

--- a/contracts/DebtKernel.sol
+++ b/contracts/DebtKernel.sol
@@ -181,10 +181,15 @@ contract DebtKernel is Pausable {
         issueDebtAgreement(creditor, debtOrder.issuance);
 
         // Register debt agreement's start with terms contract
-        require(
-            TermsContract(debtOrder.issuance.termsContract)
-                .registerTermStart(debtOrder.issuance.issuanceHash)
-        );
+        if (debtOrder.issuance.termsContract != address(0)) {
+            require(
+                TermsContract(debtOrder.issuance.termsContract)
+                    .registerTermStart(
+                        debtOrder.issuance.issuanceHash,
+                        debtOrder.issuance.debtor
+                    )
+            );
+        }
 
         // Transfer principal to debtor
         if (debtOrder.principalAmount > 0) {

--- a/contracts/TermsContract.sol
+++ b/contracts/TermsContract.sol
@@ -32,9 +32,11 @@ interface TermsContract {
      ///    must THROW.  Similarly, if this method is called by any contract other
      ///    than the current DebtKernel, must THROW.
      /// @param  agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
+     /// @param  debtor address. The debtor in this particular issuance.
      /// @return _success bool. Acknowledgment of whether
     function registerTermStart(
-        bytes32 agreementId
+        bytes32 agreementId,
+        address debtor
     ) public returns (bool _success);
 
      /// When called, the registerRepayment function records the debtor's

--- a/contracts/examples/CompoundInterestTermsContract.sol
+++ b/contracts/examples/CompoundInterestTermsContract.sol
@@ -137,9 +137,11 @@ contract CompoundInterestTermsContract is TermsContract {
     ///    we simply validate DebtKernel is the transaction sender, and return
     ///    `true` if the debt agreement is associated with this terms contract.
     /// @param  agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
+    /// @param  debtor address. The debtor in this particular issuance.
     /// @return _success bool. Acknowledgment of whether
     function registerTermStart(
-        bytes32 agreementId
+        bytes32 agreementId,
+        address debtor
     )
         public
         onlyDebtKernel

--- a/contracts/examples/SimpleInterestTermsContract.sol
+++ b/contracts/examples/SimpleInterestTermsContract.sol
@@ -86,9 +86,11 @@ contract SimpleInterestTermsContract is TermsContract {
     ///    we simply validate DebtKernel is the transaction sender, and return
     ///    `true` if the debt agreement is associated with this terms contract.
     /// @param  agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
+    /// @param  debtor address. The debtor in this particular issuance.
     /// @return _success bool. Acknowledgment of whether
     function registerTermStart(
-        bytes32 agreementId
+        bytes32 agreementId,
+        address debtor
     )
         public
         onlyDebtKernel

--- a/contracts/test/mocks/MockTermsContract.sol
+++ b/contracts/test/mocks/MockTermsContract.sol
@@ -70,28 +70,36 @@ contract MockTermsContract is MockContract {
     }
 
     function registerTermStart(
-        bytes32 agreementId
+        bytes32 agreementId,
+        address debtor
     )
         public
         returns (bool _registered)
     {
-        functionCalledWithArgs("registerTermStart", agreementId);
+        functionCalledWithArgs("registerTermStart", keccak256(agreementId, debtor));
 
-        return getMockReturnValue("registerTermStart", agreementId) == bytes32(1);
+        return getMockReturnValue(
+            "registerTermStart",
+            keccak256(agreementId, debtor)
+        ) == bytes32(1);
     }
 
-    function mockRegisterTermStartReturnValue(bytes32 agreementId, bool success)
+    function mockRegisterTermStartReturnValue(bytes32 agreementId, address debtor, bool success)
         public
     {
-        mockReturnValue("registerTermStart", agreementId, success ? bytes32(1) : bytes32(0));
+        mockReturnValue(
+            "registerTermStart",
+            keccak256(agreementId, debtor),
+            success ? bytes32(1) : bytes32(0)
+        );
     }
 
-    function wasRegisterTermStartCalledWith(bytes32 agreementId)
+    function wasRegisterTermStartCalledWith(bytes32 agreementId, address debtor)
         public
         view
         returns (bool _wasCalled)
     {
-        return wasFunctionCalledWithArgs("registerTermStart", agreementId);
+        return wasFunctionCalledWithArgs("registerTermStart", keccak256(agreementId, debtor));
     }
 
     function getFunctionList()

--- a/contracts/test/terms_contracts/DummyCollateralizedContract.sol
+++ b/contracts/test/terms_contracts/DummyCollateralizedContract.sol
@@ -16,7 +16,8 @@ contract DummyCollateralizedContract is Collateralized {
     /* Naive `TermsContract` interface implementation. */
 
     function registerTermStart(
-        bytes32 agreementId
+        bytes32 agreementId,
+        address debtor
     ) public returns (bool _success) {
         return true;
     }

--- a/contracts/test/terms_contracts/IncompatibleTermsContract.sol
+++ b/contracts/test/terms_contracts/IncompatibleTermsContract.sol
@@ -37,7 +37,8 @@ contract IncompatibleTermsContract is TermsContract {
     /// @param  agreementId bytes32. The agreement id (issuance hash) of the debt agreement to which this pertains.
     /// @return _success bool. Acknowledgment of whether
     function registerTermStart(
-        bytes32 agreementId
+        bytes32 agreementId,
+        address debtor
     )
         public
         returns (bool _success)

--- a/test/ts/unit/compound_interest_terms_contract.ts
+++ b/test/ts/unit/compound_interest_terms_contract.ts
@@ -54,10 +54,11 @@ contract("CompoundInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
     let mockTokenTransferProxy: MockTokenTransferProxyContract;
 
     const CONTRACT_OWNER = ACCOUNTS[0];
-    const PAYER = ACCOUNTS[1];
-    const BENEFICIARY = ACCOUNTS[2];
-    const MOCK_DEBT_KERNEL_ADDRESS = ACCOUNTS[3];
-    const ATTACKER = ACCOUNTS[4];
+    const DEBTOR = ACCOUNTS[1];
+    const PAYER = ACCOUNTS[2];
+    const BENEFICIARY = ACCOUNTS[3];
+    const MOCK_DEBT_KERNEL_ADDRESS = ACCOUNTS[4];
+    const ATTACKER = ACCOUNTS[5];
 
     const TERMS_CONTRACT_PARAMETERS = web3.sha3(
         "any 32 byte hex value can represent the terms contract's parameters",
@@ -176,9 +177,13 @@ contract("CompoundInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
         describe("agent who is not DebtKernel calls registerTermStart", () => {
             it("should throw", async () => {
                 await expect(
-                    termsContract.registerTermStart.sendTransactionAsync(ARBITRARY_AGREEMENT_ID, {
-                        from: ATTACKER,
-                    }),
+                    termsContract.registerTermStart.sendTransactionAsync(
+                        ARBITRARY_AGREEMENT_ID,
+                        DEBTOR,
+                        {
+                            from: ATTACKER,
+                        },
+                    ),
                 ).to.eventually.be.rejectedWith(REVERT_ERROR);
             });
         });
@@ -186,9 +191,13 @@ contract("CompoundInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
         describe("agent who is DebtKernel calls registerTermStart", () => {
             it("should not throw", async () => {
                 await expect(
-                    termsContract.registerTermStart.sendTransactionAsync(ARBITRARY_AGREEMENT_ID, {
-                        from: MOCK_DEBT_KERNEL_ADDRESS,
-                    }),
+                    termsContract.registerTermStart.sendTransactionAsync(
+                        ARBITRARY_AGREEMENT_ID,
+                        DEBTOR,
+                        {
+                            from: MOCK_DEBT_KERNEL_ADDRESS,
+                        },
+                    ),
                 ).to.eventually.be.fulfilled;
             });
         });

--- a/test/ts/unit/debt_kernel.ts
+++ b/test/ts/unit/debt_kernel.ts
@@ -245,6 +245,7 @@ contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
                     await mockTermsContract.reset.sendTransactionAsync();
                     await mockTermsContract.mockRegisterTermStartReturnValue.sendTransactionAsync(
                         debtOrder.getIssuanceCommitment().getHash(),
+                        debtOrder.getDebtor(),
                         true,
                     );
 
@@ -336,6 +337,7 @@ contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
                     await expect(
                         mockTermsContract.wasRegisterTermStartCalledWith.callAsync(
                             debtOrder.getIssuanceCommitment().getHash(),
+                            debtOrder.getDebtor(),
                         ),
                     ).to.eventually.be.true;
                 });
@@ -743,6 +745,7 @@ contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
 
                     await mockTermsContract.mockRegisterTermStartReturnValue.sendTransactionAsync(
                         debtOrder.getIssuanceCommitment().getHash(),
+                        debtOrder.getDebtor(),
                         false,
                     );
                 });

--- a/test/ts/unit/simple_interest_terms_contract.ts
+++ b/test/ts/unit/simple_interest_terms_contract.ts
@@ -37,10 +37,11 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
     let mockTokenTransferProxy: MockTokenTransferProxyContract;
 
     const CONTRACT_OWNER = ACCOUNTS[0];
-    const PAYER = ACCOUNTS[1];
-    const BENEFICIARY = ACCOUNTS[2];
-    const MOCK_DEBT_KERNEL_ADDRESS = ACCOUNTS[3];
-    const ATTACKER = ACCOUNTS[4];
+    const DEBTOR = ACCOUNTS[1];
+    const PAYER = ACCOUNTS[2];
+    const BENEFICIARY = ACCOUNTS[3];
+    const MOCK_DEBT_KERNEL_ADDRESS = ACCOUNTS[4];
+    const ATTACKER = ACCOUNTS[5];
 
     const TERMS_CONTRACT_PARAMETERS = web3.sha3(
         "any 32 byte hex value can represent the terms contract's parameters",
@@ -137,9 +138,13 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
         describe("agent who is not DebtKernel calls registerTermStart", () => {
             it("should throw", async () => {
                 await expect(
-                    termsContract.registerTermStart.sendTransactionAsync(ARBITRARY_AGREEMENT_ID, {
-                        from: ATTACKER,
-                    }),
+                    termsContract.registerTermStart.sendTransactionAsync(
+                        ARBITRARY_AGREEMENT_ID,
+                        DEBTOR,
+                        {
+                            from: ATTACKER,
+                        },
+                    ),
                 ).to.eventually.be.rejectedWith(REVERT_ERROR);
             });
         });
@@ -147,9 +152,13 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
         describe("agent who is DebtKernel calls registerTermStart", () => {
             it("should not throw", async () => {
                 await expect(
-                    termsContract.registerTermStart.sendTransactionAsync(ARBITRARY_AGREEMENT_ID, {
-                        from: MOCK_DEBT_KERNEL_ADDRESS,
-                    }),
+                    termsContract.registerTermStart.sendTransactionAsync(
+                        ARBITRARY_AGREEMENT_ID,
+                        DEBTOR,
+                        {
+                            from: MOCK_DEBT_KERNEL_ADDRESS,
+                        },
+                    ),
                 ).to.eventually.be.fulfilled;
             });
         });


### PR DESCRIPTION
This PR introduces the following changes:

- Add a `debtor` argument to the `registerTermStart` call signature in the terms contract interface, given that, without it, the terms contract has no means of determining who the given agreement's associated debtor is.
- Patch tests / mocks which are broken by this change.