### PR TITLE
Fixes suggested by saturnial + graeme to PR#45

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "compile": "truffle compile --all",
     "migrate": "truffle migrate",
     "prettify": "prettier --write test/ts/**/*.ts types/**/*.ts types/*.ts artifacts/*.ts",
-    "test": "npm run compile; npm run generate-typings; npm run transpile; npm run migrate; truffle test transpiled/test/ts/unit/collateralized/collateralized_contract.js",
+    "test": "npm run compile; npm run generate-typings; npm run transpile; npm run migrate; truffle test",
     "chain": "ganache-cli --networkId 70 --accounts 20",
     "validate": "npm ls"
   },

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "solhint": "^1.1.8",
     "solidity-sha3": "^0.4.1",
     "tiny-promisify": "^1.0.0",
-    "truffle": "4.0.3",
+    "truffle": "4.0.4",
     "tslint": "^5.8.0",
     "tslint-no-unused-expression-chai": "0.0.3",
     "types-bn": "^0.0.1",

--- a/test/ts/unit/collateralized/collateralized_contract.ts
+++ b/test/ts/unit/collateralized/collateralized_contract.ts
@@ -10,9 +10,8 @@ import {
     CollateralSeized,
 } from "../../logs/collateralized_contract";
 
-import {
-    MockCollateralizedTermsContractContract,
-} from "../../../../types/generated/mock_collateralized_terms_contract";
+// tslint:disable-next-line
+import { MockCollateralizedTermsContractContract } from "../../../../types/generated/mock_collateralized_terms_contract";
 import { TokenRegistryContract } from "../../../../types/generated/token_registry";
 import { MockDebtRegistryContract } from "../../../../types/generated/mock_debt_registry";
 import { MockERC20TokenContract } from "../../../../types/generated/mock_e_r_c20_token";
@@ -26,12 +25,12 @@ import { REVERT_ERROR } from "../../test_utils/constants";
 import { RegisterTermStartRunner, ReturnCollateralRunner, SeizeCollateralRunner } from "./runners/";
 
 // scenarios
-import { UNSUCCESSFUL_COLLATERALIZATION } from "./scenarios/unsuccessful_collateralization";
-import { SUCCESSFUL_COLLATERALIZATION } from "./scenarios/successful_collateralization";
-import { UNSUCCESSFUL_SEIZURE } from "./scenarios/unsuccessful_seizure";
-import { SUCCESSFUL_SEIZURE } from "./scenarios/successful_seizure";
-import { UNSUCCESSFUL_RETURN } from "./scenarios/unsuccessful_return";
-import { SUCCESSFUL_RETURN } from "./scenarios/successful_return";
+import { UNSUCCESSFUL_COLLATERALIZATION_SCENARIOS } from "./scenarios/unsuccessful_collateralization";
+import { SUCCESSFUL_COLLATERALIZATION_SCENARIOS } from "./scenarios/successful_collateralization";
+import { UNSUCCESSFUL_SEIZURE_SCENARIOS } from "./scenarios/unsuccessful_seizure";
+import { SUCCESSFUL_SEIZURE_SCENARIOS } from "./scenarios/successful_seizure";
+import { UNSUCCESSFUL_RETURN_SCENARIOS } from "./scenarios/unsuccessful_return";
+import { SUCCESSFUL_RETURN_SCENARIOS } from "./scenarios/successful_return";
 
 import * as moment from "moment";
 
@@ -235,31 +234,31 @@ contract("CollateralizedContract (Unit Tests)", async (ACCOUNTS) => {
 
     describe("#registerTermStart", () => {
         describe("unsuccessful collateralizations", () => {
-            UNSUCCESSFUL_COLLATERALIZATION.forEach(registerTermStartRunner.testScenario);
+            UNSUCCESSFUL_COLLATERALIZATION_SCENARIOS.forEach(registerTermStartRunner.testScenario);
         });
 
         describe("successful collateralizations", () => {
-            SUCCESSFUL_COLLATERALIZATION.forEach(registerTermStartRunner.testScenario);
+            SUCCESSFUL_COLLATERALIZATION_SCENARIOS.forEach(registerTermStartRunner.testScenario);
         });
     });
 
     describe("#seizeCollateral", () => {
         describe("Unsuccessful Collateral Seizure", () => {
-            UNSUCCESSFUL_SEIZURE.forEach(seizeCollateralRunner.testScenario);
+            UNSUCCESSFUL_SEIZURE_SCENARIOS.forEach(seizeCollateralRunner.testScenario);
         });
 
         describe("Successful Collateral Seizure", () => {
-            SUCCESSFUL_SEIZURE.forEach(seizeCollateralRunner.testScenario);
+            SUCCESSFUL_SEIZURE_SCENARIOS.forEach(seizeCollateralRunner.testScenario);
         });
     });
 
     describe("#returnCollateral", () => {
         describe("Unsuccessful Collateral Return", () => {
-            UNSUCCESSFUL_RETURN.forEach(returnCollateralRunner.testScenario);
+            UNSUCCESSFUL_RETURN_SCENARIOS.forEach(returnCollateralRunner.testScenario);
         });
 
         describe("Successful Collateral Return", () => {
-            SUCCESSFUL_RETURN.forEach(returnCollateralRunner.testScenario);
+            SUCCESSFUL_RETURN_SCENARIOS.forEach(returnCollateralRunner.testScenario);
         });
     });
 });

--- a/test/ts/unit/collateralized/collateralized_contract.ts
+++ b/test/ts/unit/collateralized/collateralized_contract.ts
@@ -110,54 +110,24 @@ contract("CollateralizedContract (Unit Tests)", async (ACCOUNTS) => {
         );
 
         // Initialize scenario runners
-        registerTermStartRunner.initialize(
-            {
-                mockCollateralizedTermsContract: collateralContract,
-                mockCollateralToken: mockToken,
-                mockDebtRegistry,
-                mockTokenRegistry,
-            },
-            {
-                ATTACKER,
-                BENEFICIARY_1,
-                BENEFICIARY_2,
-                COLLATERALIZER,
-                NON_COLLATERALIZER,
-                MOCK_DEBT_KERNEL_ADDRESS,
-            },
-        );
-        seizeCollateralRunner.initialize(
-            {
-                mockCollateralizedTermsContract: collateralContract,
-                mockCollateralToken: mockToken,
-                mockDebtRegistry,
-                mockTokenRegistry,
-            },
-            {
-                ATTACKER,
-                BENEFICIARY_1,
-                BENEFICIARY_2,
-                COLLATERALIZER,
-                NON_COLLATERALIZER,
-                MOCK_DEBT_KERNEL_ADDRESS,
-            },
-        );
-        returnCollateralRunner.initialize(
-            {
-                mockCollateralizedTermsContract: collateralContract,
-                mockCollateralToken: mockToken,
-                mockDebtRegistry,
-                mockTokenRegistry,
-            },
-            {
-                ATTACKER,
-                BENEFICIARY_1,
-                BENEFICIARY_2,
-                COLLATERALIZER,
-                NON_COLLATERALIZER,
-                MOCK_DEBT_KERNEL_ADDRESS,
-            },
-        );
+        const testContracts = {
+            mockCollateralizedTermsContract: collateralContract,
+            mockCollateralToken: mockToken,
+            mockDebtRegistry,
+            mockTokenRegistry,
+        };
+        const testAccounts = {
+            ATTACKER,
+            BENEFICIARY_1,
+            BENEFICIARY_2,
+            COLLATERALIZER,
+            NON_COLLATERALIZER,
+            MOCK_DEBT_KERNEL_ADDRESS,
+        };
+
+        registerTermStartRunner.initialize(testContracts, testAccounts);
+        seizeCollateralRunner.initialize(testContracts, testAccounts);
+        returnCollateralRunner.initialize(testContracts, testAccounts);
 
         // Initialize ABI Decoder for deciphering log receipts
         ABIDecoder.addABI(collateralContract.abi);

--- a/test/ts/unit/collateralized/runners/register_term_start.ts
+++ b/test/ts/unit/collateralized/runners/register_term_start.ts
@@ -94,13 +94,21 @@ export class RegisterTermStartRunner {
 
             if (scenario.succeeds) {
                 it("should register without throwing", async () => {
-                    txHash = await mockCollateralizedTermsContract.registerTermStart.sendTransactionAsync(
-                        scenario.agreementId,
-                        COLLATERALIZER,
-                        { from: scenario.from(MOCK_DEBT_KERNEL_ADDRESS, ATTACKER) },
-                    );
+                    await expect(
+                        new Promise(async (resolve, reject) => {
+                            try {
+                                txHash = await mockCollateralizedTermsContract.registerTermStart.sendTransactionAsync(
+                                    scenario.agreementId,
+                                    COLLATERALIZER,
+                                    { from: scenario.from(MOCK_DEBT_KERNEL_ADDRESS, ATTACKER) },
+                                );
 
-                    expect(true);
+                                resolve(txHash);
+                            } catch (e) {
+                                reject(e);
+                            }
+                        }),
+                    ).to.eventually.not.be.rejected;
                 });
 
                 it("should store record of collateralization", async () => {

--- a/test/ts/unit/collateralized/runners/return_collateral.ts
+++ b/test/ts/unit/collateralized/runners/return_collateral.ts
@@ -144,12 +144,20 @@ export class ReturnCollateralRunner {
 
             if (scenario.succeeds) {
                 it("should not throw", async () => {
-                    txHash = await mockCollateralizedTermsContract.returnCollateral.sendTransactionAsync(
-                        scenario.agreementId,
-                        { from: scenario.from(COLLATERALIZER, NON_COLLATERALIZER) },
-                    );
+                    await expect(
+                        new Promise(async (resolve, reject) => {
+                            try {
+                                txHash = await mockCollateralizedTermsContract.returnCollateral.sendTransactionAsync(
+                                    scenario.agreementId,
+                                    { from: scenario.from(COLLATERALIZER, NON_COLLATERALIZER) },
+                                );
 
-                    expect(true);
+                                resolve(txHash);
+                            } catch (e) {
+                                reject(e);
+                            }
+                        }),
+                    ).to.eventually.not.be.rejected;
                 });
 
                 it("should erase record of current collateralization", async () => {

--- a/test/ts/unit/collateralized/runners/seize_collateral.ts
+++ b/test/ts/unit/collateralized/runners/seize_collateral.ts
@@ -138,12 +138,20 @@ export class SeizeCollateralRunner {
 
             if (scenario.succeeds) {
                 it("should not throw", async () => {
-                    txHash = await mockCollateralizedTermsContract.seizeCollateral.sendTransactionAsync(
-                        scenario.agreementId,
-                        { from: scenario.from(BENEFICIARY_1, BENEFICIARY_2) },
-                    );
+                    await expect(
+                        new Promise(async (resolve, reject) => {
+                            try {
+                                txHash = await mockCollateralizedTermsContract.seizeCollateral.sendTransactionAsync(
+                                    scenario.agreementId,
+                                    { from: scenario.from(BENEFICIARY_1, BENEFICIARY_2) },
+                                );
 
-                    expect(true);
+                                resolve(txHash);
+                            } catch (e) {
+                                reject(e);
+                            }
+                        }),
+                    ).to.eventually.not.be.rejected;
                 });
 
                 it("should erase record of current collateralization", async () => {

--- a/test/ts/unit/collateralized/scenarios/successful_collateralization.ts
+++ b/test/ts/unit/collateralized/scenarios/successful_collateralization.ts
@@ -14,7 +14,7 @@ const defaultArgs = {
     termsContract: (collateralizedContract: string, attacker: string) => collateralizedContract,
 };
 
-export const SUCCESSFUL_COLLATERALIZATION: RegisterTermStartScenario[] = [
+export const SUCCESSFUL_COLLATERALIZATION_SCENARIOS: RegisterTermStartScenario[] = [
     {
         description: "Collateralize 0.005 REP with 20 day grace period",
         ...defaultArgs,

--- a/test/ts/unit/collateralized/scenarios/successful_return.ts
+++ b/test/ts/unit/collateralized/scenarios/successful_return.ts
@@ -7,7 +7,7 @@ import * as moment from "moment";
 // utils
 import * as Units from "../../../test_utils/units";
 
-export const SUCCESSFUL_RETURN: ReturnCollateralScenario[] = [
+export const SUCCESSFUL_RETURN_SCENARIOS: ReturnCollateralScenario[] = [
     {
         description: "Debt's term has lapsed and debt has been repaid",
         collateralAmount: Units.ether(3),

--- a/test/ts/unit/collateralized/scenarios/successful_seizure.ts
+++ b/test/ts/unit/collateralized/scenarios/successful_seizure.ts
@@ -27,7 +27,7 @@ const defaultArgs = {
     succeeds: true,
 };
 
-export const SUCCESSFUL_SEIZURE: SeizeCollateralScenario[] = [
+export const SUCCESSFUL_SEIZURE_SCENARIOS: SeizeCollateralScenario[] = [
     {
         description:
             "(Grace Period = 0 Days) Debt entered default > grace period's length ago, no repayments since",

--- a/test/ts/unit/collateralized/scenarios/unsuccessful_collateralization.ts
+++ b/test/ts/unit/collateralized/scenarios/unsuccessful_collateralization.ts
@@ -20,7 +20,7 @@ const defaultArgs = {
     termsContractParameters: "0x00000000000000000000000000000000000000200000000de0b6b3a764000001",
 };
 
-export const UNSUCCESSFUL_COLLATERALIZATION: RegisterTermStartScenario[] = [
+export const UNSUCCESSFUL_COLLATERALIZATION_SCENARIOS: RegisterTermStartScenario[] = [
     {
         description: "Caller is not debt kernel",
         ...defaultArgs,

--- a/test/ts/unit/collateralized/scenarios/unsuccessful_return.ts
+++ b/test/ts/unit/collateralized/scenarios/unsuccessful_return.ts
@@ -39,7 +39,7 @@ const defaultArgs = {
     succeeds: false,
 };
 
-export const UNSUCCESSFUL_RETURN: ReturnCollateralScenario[] = [
+export const UNSUCCESSFUL_RETURN_SCENARIOS: ReturnCollateralScenario[] = [
     {
         description: "Debt agreement does not exist",
         ...defaultArgs,

--- a/test/ts/unit/collateralized/scenarios/unsuccessful_seizure.ts
+++ b/test/ts/unit/collateralized/scenarios/unsuccessful_seizure.ts
@@ -31,7 +31,7 @@ const defaultArgs = {
     succeeds: false,
 };
 
-export const UNSUCCESSFUL_SEIZURE: SeizeCollateralScenario[] = [
+export const UNSUCCESSFUL_SEIZURE_SCENARIOS: SeizeCollateralScenario[] = [
     {
         description: "Debt agreement does not exist",
         ...defaultArgs,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4964,9 +4964,9 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-truffle@4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-4.0.3.tgz#14ede96a7ddcce038dae98e0ceb6077cc0b81f81"
+truffle@4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/truffle/-/truffle-4.0.4.tgz#b447cb3b0469054413b5ff421f6e8baeefddb2be"
   dependencies:
     mocha "^3.4.2"
     original-require "^1.0.1"


### PR DESCRIPTION
This PR introduces the following fixes:

- clean up test specification in package.json
- bumps truffle version back up to 4.0.4
- tests more explicitly for whether or not scenarios are throwing in scenario runners
- add '_SCENARIOS' suffix to the variables we use to represent our test scenarios.
- cleaned up runner initialization by reducing redundant argument declarations.

