### PR TITLE
Add `getTokenSymbolByIndex` method

### DIFF
--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -48,7 +48,7 @@ contract TokenRegistry is Ownable {
     }
 
     /**
-     * Given the known index of a token within the registry's symbol hash list,
+     * Given the known index of a token within the registry's symbol list,
      * returns the address of the token mapped to the symbol at that index.
      *
      * This is a useful utility for compactly encoding the address of a token into a
@@ -63,7 +63,7 @@ contract TokenRegistry is Ownable {
 
     /**
      * Given a symbol, resolves the index of the token the symbol is mapped to within the registry's
-     * symbol hash list.
+     * symbol list.
      */
     function getTokenIndexBySymbol(string symbol) public view returns (uint) {
         return symbolHashToTokenIndex[keccak256(symbol)];

--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -18,33 +18,33 @@ import "zeppelin-solidity/contracts/ownership/Ownable.sol";
  * contract to the Dharma community.
  */
 contract TokenRegistry is Ownable {
-    mapping (bytes32 => address) public symbolToTokenAddress;
-    mapping (bytes32 => uint) public symbolToTokenIndex;
-    bytes32[256] public tokenSymbolHashList;
-    uint8 public tokenSymbolHashListLength;
+    mapping (bytes32 => address) public symbolHashToTokenAddress;
+    mapping (bytes32 => uint) public symbolHashToTokenIndex;
+    string[256] public tokenSymbolList;
+    uint8 public tokenSymbolListLength;
 
     /**
      * Maps the given symbol to the given token address.
      */
     function setTokenAddress(string symbol, address token) public onlyOwner {
-        require(tokenSymbolHashListLength < 256);
+        require(tokenSymbolListLength < 256);
 
         bytes32 symbolHash = keccak256(symbol);
 
-        if (symbolToTokenAddress[symbolHash] == address(0)) {
-            tokenSymbolHashList[tokenSymbolHashListLength] = symbolHash;
-            symbolToTokenAddress[symbolHash] = tokenSymbolHashListLength;
-            tokenSymbolHashListLength++;
+        if (symbolHashToTokenAddress[symbolHash] == address(0)) {
+            tokenSymbolList[tokenSymbolListLength] = symbol;
+            symbolHashToTokenAddress[symbolHash] = tokenSymbolListLength;
+            tokenSymbolListLength++;
         }
 
-        symbolToTokenAddress[symbolHash] = token;
+        symbolHashToTokenAddress[symbolHash] = token;
     }
 
     /**
      * Given a symbol, resolves the current address of the token the symbol is mapped to.
      */
     function getTokenAddressBySymbol(string symbol) public view returns (address) {
-        return symbolToTokenAddress[keccak256(symbol)];
+        return symbolHashToTokenAddress[keccak256(symbol)];
     }
 
     /**
@@ -56,7 +56,9 @@ contract TokenRegistry is Ownable {
      * a 256 slot array, we can represent a token by a 1 byte uint instead of a 20 byte address.
      */
     function getTokenAddressByIndex(uint index) public view returns (address) {
-        return symbolToTokenAddress[tokenSymbolHashList[index]];
+        string storage symbol = tokenSymbolList[index];
+
+        return symbolHashToTokenAddress[keccak256(symbol)];
     }
 
     /**
@@ -64,6 +66,14 @@ contract TokenRegistry is Ownable {
      * symbol hash list.
      */
     function getTokenIndexBySymbol(string symbol) public view returns (uint) {
-        return symbolToTokenIndex[keccak256(symbol)];
+        return symbolHashToTokenIndex[keccak256(symbol)];
+    }
+
+    /**
+     * Given an index, resolves the symbol of the token at that index in the registry's
+     * token symbol list.
+     */
+    function getTokenSymbolByIndex(uint index) public view returns (string) {
+        return tokenSymbolList[index];
     }
 }


### PR DESCRIPTION
This PR introduces the following changes:

- No longer list tokens by their symbols' hashes, but rather by the symbols themselves
- add a `getTokenSymbolByIndex` method to the `TokenRegistry`