### PR TITLE
test: remove sleep from circle build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,5 +11,4 @@ jobs:
             name: testrpc
             command: yarn chain
             background: true
-        - run: sleep 90
         - run: yarn test


### PR DESCRIPTION
Unlike for dharma.js, I don't think that there is a reason to wait between `yarn chain` and `yarn test` here.