### PR TITLE
Account for interest rate decimals in calculating expected repayment value

### DIFF
--- a/artifacts/index.ts
+++ b/artifacts/index.ts
@@ -4,11 +4,9 @@ import { RepaymentRouter } from "./ts/RepaymentRouter";
 import { TokenTransferProxy } from "./ts/TokenTransferProxy";
 import { TokenRegistry } from "./ts/TokenRegistry";
 import { DebtToken } from "./ts/DebtToken";
-import { TermsContractRegistry } from "./ts/TermsContractRegistry";
 import { DummyToken } from "./ts/DummyToken";
 import { ERC20 } from "./ts/ERC20";
 import { SimpleInterestTermsContract } from "./ts/SimpleInterestTermsContract";
-import { CompoundInterestTermsContract } from "./ts/CompoundInterestTermsContract";
 import { TermsContract } from "./ts/TermsContract";
 
 export {
@@ -18,10 +16,8 @@ export {
     TokenTransferProxy,
     TokenRegistry,
     DebtToken,
-    TermsContractRegistry,
     DummyToken,
     ERC20,
     SimpleInterestTermsContract,
-    CompoundInterestTermsContract,
     TermsContract,
 };

--- a/test/ts/unit/simple_interest_terms_contract.ts
+++ b/test/ts/unit/simple_interest_terms_contract.ts
@@ -612,17 +612,21 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
 
             const ORIGIN_MOMENT = moment();
             const BLOCK_ISSUANCE_TIMESTAMP = ORIGIN_MOMENT.unix();
-            const INTEREST_RATE_SCALING_FACTOR = new BigNumber(10 ** 4);
-
-            const INSTALLMENT_AMOUNT = principalAmount
-                .mul(interestRate)
-                .div(INTEREST_RATE_SCALING_FACTOR)
-                .plus(principalAmount.div(termLength));
 
             const ZERO_AMOUNT = Units.ether(0);
-            const FULL_AMOUNT = INSTALLMENT_AMOUNT.mul(termLength);
+            let INSTALLMENT_AMOUNT: BigNumber;
+            let FULL_AMOUNT: BigNumber;
 
             before(async () => {
+                const INTEREST_RATE_SCALING_FACTOR = await termsContract.INTEREST_RATE_SCALING_FACTOR.callAsync();
+
+                INSTALLMENT_AMOUNT = principalAmount
+                    .mul(interestRate)
+                    .div(INTEREST_RATE_SCALING_FACTOR)
+                    .plus(principalAmount.div(termLength));
+
+                FULL_AMOUNT = INSTALLMENT_AMOUNT.mul(termLength);
+
                 await mockRegistry.mockGetTermsContractReturnValueFor.sendTransactionAsync(
                     ARBITRARY_AGREEMENT_ID,
                     termsContract.address,

--- a/test/ts/unit/simple_interest_terms_contract.ts
+++ b/test/ts/unit/simple_interest_terms_contract.ts
@@ -612,9 +612,11 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
 
             const ORIGIN_MOMENT = moment();
             const BLOCK_ISSUANCE_TIMESTAMP = ORIGIN_MOMENT.unix();
+            const INTEREST_RATE_SCALING_FACTOR = new BigNumber(10 ** 4);
 
             const INSTALLMENT_AMOUNT = principalAmount
                 .mul(interestRate)
+                .div(INTEREST_RATE_SCALING_FACTOR)
                 .plus(principalAmount.div(termLength));
 
             const ZERO_AMOUNT = Units.ether(0);


### PR DESCRIPTION
This PR introduces the following changes:

- Factors in scaling factor for fixed point interest rate when calculating the expected repayment value of a debt agreement.  This is motivated by the fact that Solidity doesn't support floating point numbers -- as such, we have to choose arbitrary scaling factors and represent floating point numbers (such as interest rates) as fixed point values.  In this case, we choose a scaling factor of 10^4.
- Patches test suite associated with the simple interest terms contract.