### PR TITLE
fix: artifacts/index.ts imports from nonexistant TermsContractRegistry

### DIFF
--- a/artifacts/index.ts
+++ b/artifacts/index.ts
@@ -7,7 +7,6 @@ import { DebtToken } from "./ts/DebtToken";
 import { DummyToken } from "./ts/DummyToken";
 import { ERC20 } from "./ts/ERC20";
 import { SimpleInterestTermsContract } from "./ts/SimpleInterestTermsContract";
-import { CompoundInterestTermsContract } from "./ts/CompoundInterestTermsContract";
 import { TermsContract } from "./ts/TermsContract";
 
 export {
@@ -20,6 +19,5 @@ export {
     DummyToken,
     ERC20,
     SimpleInterestTermsContract,
-    CompoundInterestTermsContract,
     TermsContract,
 };

--- a/artifacts/index.ts
+++ b/artifacts/index.ts
@@ -4,7 +4,6 @@ import { RepaymentRouter } from "./ts/RepaymentRouter";
 import { TokenTransferProxy } from "./ts/TokenTransferProxy";
 import { TokenRegistry } from "./ts/TokenRegistry";
 import { DebtToken } from "./ts/DebtToken";
-import { TermsContractRegistry } from "./ts/TermsContractRegistry";
 import { DummyToken } from "./ts/DummyToken";
 import { ERC20 } from "./ts/ERC20";
 import { SimpleInterestTermsContract } from "./ts/SimpleInterestTermsContract";
@@ -18,7 +17,6 @@ export {
     TokenTransferProxy,
     TokenRegistry,
     DebtToken,
-    TermsContractRegistry,
     DummyToken,
     ERC20,
     SimpleInterestTermsContract,


### PR DESCRIPTION
This PR introduces the following changes:

- Removes outdated import statements from `artifacts/index.ts`