### PR TITLE
test: add test util to send transaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "copyfiles": "^1.2.0",
     "ethereumjs-abi": "^0.6.4",
     "ethereumjs-util": "^5.1.2",
+    "ethjs-abi": "^0.2.1",
     "fs-extra": "^5.0.0",
     "ganache-cli": "^6.1.0",
     "import-sort-cli": "^4.2.0",

--- a/test/ts/test_utils/send_transactions.ts
+++ b/test/ts/test_utils/send_transactions.ts
@@ -1,0 +1,43 @@
+// Web3 types can be found here:
+// https://github.com/0xProject/0x-monorepo/tree/development/packages/types
+
+import * as Web3 from "web3";
+import ethjsABI = require("ethjs-abi");
+import { TxData } from "../../../types/common";
+
+function filterMethodABI(abi: any[]): Web3.MethodAbi[] {
+    return abi.filter((abiDef) => abiDef.type === "function");
+}
+
+function findMethod(abi: Web3.AbiDefinition[], name: string, inputTypes: string): Web3.MethodAbi {
+    const methodAbi = filterMethodABI(abi).find((abiDef) => {
+        const methodArgs = abiDef.inputs.map((input) => input.type).join(",");
+        return abiDef.name === name && methodArgs === inputTypes;
+    });
+
+    if (methodAbi) {
+        return methodAbi;
+    }
+
+    throw new Error(`Method: ${name} with input types: ${inputTypes} is not found`);
+}
+
+// sendTransaction is a util function to send a transaction to any overloaded
+// method of a contract.
+// Truffle contract instance cannot handle overloaded methods
+// (truffle will only handle the first implementation of the method).
+export default function sendTransaction(
+    truffleContractInstance: any,
+    methodName: string,
+    inputTypes: string,
+    inputVals: any[],
+    txData: TxData = {},
+): Promise<string> {
+    const abiMethod = findMethod(truffleContractInstance.abi, methodName, inputTypes);
+    const encodedData = ethjsABI.encodeMethod(abiMethod, inputVals);
+
+    return truffleContractInstance.sendTransaction({
+        data: encodedData,
+        ...txData,
+    });
+}

--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -1,6 +1,7 @@
 /* tslint:disable */
 declare module "chai-bignumber";
 declare module "ethereumjs-abi";
+declare module "ethjs-abi";
 declare module "child-process-promise";
 
 /**


### PR DESCRIPTION
Truffle contract instance cannot handle overloaded methods.
This PR adds a test util to send transaction to an overloaded method.

Example:
```javascript

// send tx to
// safeTransferFrom(address _from, address _to, uint256 _tokenId)
await sendTransaction(
    debtTokenTruffle, // truffle contract instance
    "safeTransferFrom",
    "address,address,uint256",
    [
        TOKEN_OWNER_1,
        TOKEN_OWNER_2,
        TOKEN_ID_1,
    ],
    { from: TOKEN_OWNER_1 }
 );

// send tx to
// safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes _data)
await sendTransaction(
    debtTokenTruffle, // truffle contract instance
    "safeTransferFrom",
    "address,address,uint256,bytes",
    [
        TOKEN_OWNER_1,
        TOKEN_OWNER_2,
        TOKEN_ID_1,
        "some data",
    ],
    { from: TOKEN_OWNER_1 }
 );
```