### PR TITLE
fix: interest rate should accrue on aggregate basis as opposed to periodically

### DIFF
--- a/contracts/examples/SimpleInterestTermsContract.sol
+++ b/contracts/examples/SimpleInterestTermsContract.sol
@@ -332,11 +332,9 @@ contract SimpleInterestTermsContract is TermsContract {
         // scaled-up, fixed point representation, we have to
         // downscale the result of the interest payment computation
         // by the scaling factor we choose for interest rates.
-        uint interestPayment = params.principalAmount
+        uint totalInterest = params.principalAmount
             .mul(params.interestRate)
             .div(INTEREST_RATE_SCALING_FACTOR);
-
-        uint totalInterest = interestPayment.mul(params.termLengthInAmortizationUnits);
 
         return params.principalAmount.add(totalInterest);
     }

--- a/test/ts/unit/collateralized_simple_interest_terms_contract.ts
+++ b/test/ts/unit/collateralized_simple_interest_terms_contract.ts
@@ -665,12 +665,13 @@ contract("CollateralizedSimpleInterestTermsContract (Unit Tests)", async (ACCOUN
             before(async () => {
                 const INTEREST_RATE_SCALING_FACTOR = await termsContract.INTEREST_RATE_SCALING_FACTOR.callAsync();
 
-                INSTALLMENT_AMOUNT = principalAmount
+                const TOTAL_INTEREST = principalAmount
                     .mul(interestRate)
-                    .div(INTEREST_RATE_SCALING_FACTOR)
-                    .plus(principalAmount.div(termLength));
+                    .div(INTEREST_RATE_SCALING_FACTOR);
 
-                FULL_AMOUNT = INSTALLMENT_AMOUNT.mul(termLength);
+                FULL_AMOUNT = principalAmount.add(TOTAL_INTEREST);
+
+                INSTALLMENT_AMOUNT = FULL_AMOUNT.div(termLength);
 
                 await mockRegistry.mockGetTermsContractReturnValueFor.sendTransactionAsync(
                     ARBITRARY_AGREEMENT_ID,

--- a/test/ts/unit/simple_interest_terms_contract.ts
+++ b/test/ts/unit/simple_interest_terms_contract.ts
@@ -620,12 +620,13 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
             before(async () => {
                 const INTEREST_RATE_SCALING_FACTOR = await termsContract.INTEREST_RATE_SCALING_FACTOR.callAsync();
 
-                INSTALLMENT_AMOUNT = principalAmount
+                const TOTAL_INTEREST = principalAmount
                     .mul(interestRate)
-                    .div(INTEREST_RATE_SCALING_FACTOR)
-                    .plus(principalAmount.div(termLength));
+                    .div(INTEREST_RATE_SCALING_FACTOR);
 
-                FULL_AMOUNT = INSTALLMENT_AMOUNT.mul(termLength);
+                FULL_AMOUNT = principalAmount.add(TOTAL_INTEREST);
+
+                INSTALLMENT_AMOUNT = FULL_AMOUNT.div(termLength);
 
                 await mockRegistry.mockGetTermsContractReturnValueFor.sendTransactionAsync(
                     ARBITRARY_AGREEMENT_ID,


### PR DESCRIPTION
This PR introduces the following changes:

- Interest rates in SimpleInterestTermsContract and inheriting contracts accrue on an aggregate term basis, as opposed to once per amortization period.
- patches tests associated with this change.