### PR TITLE
Interest rate calculations must account for orders of magnitude in percentages

### DIFF
--- a/contracts/examples/SimpleInterestTermsContract.sol
+++ b/contracts/examples/SimpleInterestTermsContract.sol
@@ -52,7 +52,8 @@ contract SimpleInterestTermsContract is TermsContract {
     uint public constant INTEREST_RATE_SCALING_FACTOR = 10 ** 4;
     // The number of orders of magnitudes an interest rate (denominated in %)
     // must be scaled down in order to multiply it by a principal
-    // amount and produce the correct interest amount.
+    // amount and produce the correct interest amount --
+    //      e.g. 10.342% of 100ETH = (10.342 / 100) * 100ETH = 10.342ETH
     uint public constant PERCENTAGE_SCALING_FACTOR = 10 ** 2;
 
     mapping (bytes32 => uint) public valueRepaid;

--- a/contracts/examples/SimpleInterestTermsContract.sol
+++ b/contracts/examples/SimpleInterestTermsContract.sol
@@ -32,11 +32,28 @@ contract SimpleInterestTermsContract is TermsContract {
 
     struct SimpleInterestParams {
         address principalTokenAddress;
+
         uint principalAmount;
+
+        // This field contains an encoded interest rate of the debt.
+        //
+        // To get an interest rate in the multiplier format, you need to
+        // divide it by INTEREST_RATE_SCALING_FACTOR_MULTIPLIER.
+        // For example for 1% interest rate (0.01 in the multiplier format)
+        // this field will contain 0.01 * INTEREST_RATE_SCALING_FACTOR_MULTIPLIER = 10'000.
+        // 
+        // To get an interest rate in the percent format, you need to
+        // divide it by INTEREST_RATE_SCALING_FACTOR_PERCENT.
+        // For example for 1% interest rate (1 in the percent format)
+        // this field will contain 1 * INTEREST_RATE_SCALING_FACTOR_PERCENT = 10'000.
         uint interestRate;
+
         uint termStartUnixTimestamp;
+
         uint termEndUnixTimestamp;
+
         AmortizationUnitType amortizationUnitType;
+
         uint termLengthInAmortizationUnits;
     }
 
@@ -46,15 +63,8 @@ contract SimpleInterestTermsContract is TermsContract {
     uint public constant MONTH_LENGTH_IN_SECONDS = DAY_LENGTH_IN_SECONDS * 30;
     uint public constant YEAR_LENGTH_IN_SECONDS = DAY_LENGTH_IN_SECONDS * 365;
 
-    // Given that Solidity doesn't support floating points, we represent
-    // decimal values (such as interestRate) with fixed point values
-    // scaled up by a factor of 10000 -- e.g. 10.342% => 1034250
-    uint public constant INTEREST_RATE_SCALING_FACTOR = 10 ** 4;
-    // The number of orders of magnitudes an interest rate (denominated in %)
-    // must be scaled down in order to multiply it by a principal
-    // amount and produce the correct interest amount --
-    //      e.g. 10.342% of 100ETH = (10.342 / 100) * 100ETH = 10.342ETH
-    uint public constant PERCENTAGE_SCALING_FACTOR = 10 ** 2;
+    uint public constant INTEREST_RATE_SCALING_FACTOR_PERCENT = 10 ** 4;
+    uint public constant INTEREST_RATE_SCALING_FACTOR_MULTIPLIER = INTEREST_RATE_SCALING_FACTOR_PERCENT * 100;
 
     mapping (bytes32 => uint) public valueRepaid;
 
@@ -356,8 +366,7 @@ contract SimpleInterestTermsContract is TermsContract {
         // by the scaling factor we choose for interest rates.
         uint totalInterest = params.principalAmount
             .mul(params.interestRate)
-            .div(INTEREST_RATE_SCALING_FACTOR)
-            .div(PERCENTAGE_SCALING_FACTOR);
+            .div(INTEREST_RATE_SCALING_FACTOR_MULTIPLIER);
 
         return params.principalAmount.add(totalInterest);
     }

--- a/contracts/examples/SimpleInterestTermsContract.sol
+++ b/contracts/examples/SimpleInterestTermsContract.sol
@@ -50,6 +50,10 @@ contract SimpleInterestTermsContract is TermsContract {
     // decimal values (such as interestRate) with fixed point values
     // scaled up by a factor of 10000 -- e.g. 10.342% => 1034250
     uint public constant INTEREST_RATE_SCALING_FACTOR = 10 ** 4;
+    // The number of orders of magnitudes an interest rate (denominated in %)
+    // must be scaled down in order to multiply it by a principal
+    // amount and produce the correct interest amount.
+    uint public constant PERCENTAGE_SCALING_FACTOR = 10 ** 2;
 
     mapping (bytes32 => uint) public valueRepaid;
 
@@ -351,7 +355,8 @@ contract SimpleInterestTermsContract is TermsContract {
         // by the scaling factor we choose for interest rates.
         uint totalInterest = params.principalAmount
             .mul(params.interestRate)
-            .div(INTEREST_RATE_SCALING_FACTOR);
+            .div(INTEREST_RATE_SCALING_FACTOR)
+            .div(PERCENTAGE_SCALING_FACTOR);
 
         return params.principalAmount.add(totalInterest);
     }

--- a/test/ts/factories/terms_contract_parameters.ts
+++ b/test/ts/factories/terms_contract_parameters.ts
@@ -3,7 +3,7 @@ import { BigNumber } from "bignumber.js";
 export interface SimpleInterestContractTerms {
     principalTokenIndex: BigNumber;
     principalAmount: BigNumber;
-    interestRate: BigNumber;
+    interestRateFixedPoint: BigNumber;
     amortizationUnitType: BigNumber;
     termLengthUnits: BigNumber;
 }
@@ -35,7 +35,10 @@ export class SimpleInterestParameters extends TermsContractParameters {
             152,
         );
 
-        const interestRateShifted = TermsContractParameters.bitShiftLeft(terms.interestRate, 128);
+        const interestRateShifted = TermsContractParameters.bitShiftLeft(
+            terms.interestRateFixedPoint,
+            128,
+        );
 
         const amortizationUnitTypeShifted = TermsContractParameters.bitShiftLeft(
             terms.amortizationUnitType,

--- a/test/ts/integration/debt_kernel.ts
+++ b/test/ts/integration/debt_kernel.ts
@@ -105,7 +105,7 @@ contract("Debt Kernel (Integration Tests)", async (ACCOUNTS) => {
         const termsContractParameters = SimpleInterestParameters.pack({
             principalTokenIndex: new BigNumber(0), // Our migrations set REP up to be at index 0 of the registry
             principalAmount: Units.ether(1), // principal of 1 ether
-            interestRate: Units.percent(2.5), // interest rate of 2.5%
+            interestRateFixedPoint: Units.interestRateFixedPoint(2.5), // interest rate of 2.5%
             amortizationUnitType: new BigNumber(1), // The amortization unit type (weekly)
             termLengthUnits: new BigNumber(4), // Term length in amortization units.
         });
@@ -133,7 +133,7 @@ contract("Debt Kernel (Integration Tests)", async (ACCOUNTS) => {
             termsContractParameters,
             underwriter: UNDERWRITER,
             underwriterFee: Units.ether(0.0015),
-            underwriterRiskRating: Units.percent(1.35),
+            underwriterRiskRating: Units.underwriterRiskRatingFixedPoint(1.35),
         };
 
         orderFactory = new DebtOrderFactory(defaultOrderParams);

--- a/test/ts/integration/debt_token.ts
+++ b/test/ts/integration/debt_token.ts
@@ -103,7 +103,7 @@ contract("Debt Token (Integration Tests)", (ACCOUNTS) => {
                 termsContract: debtRegistry.address,
                 termsContractParameters: ARBITRARY_TERMS_CONTRACT_PARAMS[i],
                 underwriter: UNDERWRITERS[i],
-                underwriterRiskRating: Units.percent(3.4),
+                underwriterRiskRating: Units.underwriterRiskRatingFixedPoint(3.4),
                 version: repaymentRouterContractInstance.address,
             });
         });

--- a/test/ts/integration/examples/collateralized_simple_interest_terms_contract/runners/collateralized_simple_interest_terms_contract.ts
+++ b/test/ts/integration/examples/collateralized_simple_interest_terms_contract/runners/collateralized_simple_interest_terms_contract.ts
@@ -36,15 +36,14 @@ export abstract class CollateralizedSimpleInterestTermsContractRunner {
         this.contracts = testContracts;
     }
 
-    public abstract testScenario(scenario: RegisterRepaymentScenario | RegisterTermStartScenario): void;
+    public abstract testScenario(
+        scenario: RegisterRepaymentScenario | RegisterTermStartScenario,
+    ): void;
 
     protected async getLogs(txHash: string, event: string): Promise<DecodedLog | undefined> {
         const receipt = await web3.eth.getTransactionReceipt(txHash);
 
-        return _.find(
-            ABIDecoder.decodeLogs(receipt.logs),
-            { name: event },
-        );
+        return _.find(ABIDecoder.decodeLogs(receipt.logs), { name: event });
     }
 
     protected fillDebtOrder() {
@@ -64,7 +63,9 @@ export abstract class CollateralizedSimpleInterestTermsContractRunner {
         );
     }
 
-    protected async setupDebtOrder(scenario: RegisterRepaymentScenario | RegisterTermStartScenario) {
+    protected async setupDebtOrder(
+        scenario: RegisterRepaymentScenario | RegisterTermStartScenario,
+    ) {
         const {
             collateralizedSimpleInterestTermsContract,
             kernel,
@@ -84,7 +85,7 @@ export abstract class CollateralizedSimpleInterestTermsContractRunner {
             {
                 principalTokenIndex: scenario.principalTokenIndex,
                 principalAmount: scenario.principalAmount,
-                interestRate: scenario.interestRate,
+                interestRateFixedPoint: scenario.interestRateFixedPoint,
                 amortizationUnitType: scenario.amortizationUnitType,
                 termLengthUnits: scenario.termLengthUnits,
             },
@@ -113,7 +114,7 @@ export abstract class CollateralizedSimpleInterestTermsContractRunner {
             termsContractParameters,
             underwriter: UNDERWRITER,
             underwriterFee: Units.ether(0.0015),
-            underwriterRiskRating: Units.percent(1.35),
+            underwriterRiskRating: Units.underwriterRiskRatingFixedPoint(1.35),
         };
 
         const orderFactory = new DebtOrderFactory(defaultOrderParams);
@@ -128,18 +129,15 @@ export abstract class CollateralizedSimpleInterestTermsContractRunner {
     }
 
     protected async setBalances() {
-        const {
-            tokenTransferProxy,
-        } = this.contracts;
+        const { tokenTransferProxy } = this.contracts;
 
         const { CONTRACT_OWNER } = this.accounts;
         const debtOrder = this.debtOrder;
 
-        const token = await DummyTokenContract.at(
-            debtOrder.getPrincipalTokenAddress(),
-            web3,
-            { from: CONTRACT_OWNER, gas: DEFAULT_GAS_AMOUNT },
-        );
+        const token = await DummyTokenContract.at(debtOrder.getPrincipalTokenAddress(), web3, {
+            from: CONTRACT_OWNER,
+            gas: DEFAULT_GAS_AMOUNT,
+        });
 
         const debtor = debtOrder.getDebtor();
         const creditor = debtOrder.getCreditor();

--- a/test/ts/integration/examples/collateralized_simple_interest_terms_contract/runners/register_term_start.ts
+++ b/test/ts/integration/examples/collateralized_simple_interest_terms_contract/runners/register_term_start.ts
@@ -87,7 +87,7 @@ export class RegisterTermStartRunner extends CollateralizedSimpleInterestTermsCo
                         this.agreementId,
                         debtOrder.getPrincipalTokenAddress(),
                         debtOrder.getPrincipalAmount(),
-                        scenario.interestRate,
+                        scenario.interestRateFixedPoint,
                         scenario.amortizationUnitType,
                         scenario.termLengthUnits,
                     );
@@ -112,19 +112,23 @@ export class RegisterTermStartRunner extends CollateralizedSimpleInterestTermsCo
                 });
 
                 it("should decrement the balance for the debtor by the collateral amount", async () => {
-                   const balance = await this.contracts.dummyREPToken.balanceOf.callAsync(
-                       this.accounts.DEBTOR_1,
-                   );
+                    const balance = await this.contracts.dummyREPToken.balanceOf.callAsync(
+                        this.accounts.DEBTOR_1,
+                    );
 
-                   if (scenario.collateralTokenIndexInRegistry.equals(scenario.principalTokenIndex)) {
-                       const amountFromLoan = scenario.principalAmount.sub(scenario.debtorFee);
+                    if (
+                        scenario.collateralTokenIndexInRegistry.equals(scenario.principalTokenIndex)
+                    ) {
+                        const amountFromLoan = scenario.principalAmount.sub(scenario.debtorFee);
 
-                       expect(balance.toString()).to.equal(amountFromLoan.toString());
-                   } else {
-                       expect(balance.toString()).to.equal(
-                           scenario.collateralTokenBalance.sub(scenario.collateralAmount).toString(),
-                       );
-                   }
+                        expect(balance.toString()).to.equal(amountFromLoan.toString());
+                    } else {
+                        expect(balance.toString()).to.equal(
+                            scenario.collateralTokenBalance
+                                .sub(scenario.collateralAmount)
+                                .toString(),
+                        );
+                    }
                 });
 
                 it("should increment the collateralizer balance by the collateral amount", async () => {
@@ -138,14 +142,21 @@ export class RegisterTermStartRunner extends CollateralizedSimpleInterestTermsCo
                 if (scenario.reverts) {
                     it("should revert the transaction", async () => {
                         if (!scenario.invokedByDebtKernel) {
-                            expect(this.registerTermsStart()).to.eventually.be.rejectedWith(REVERT_ERROR);
+                            expect(this.registerTermsStart()).to.eventually.be.rejectedWith(
+                                REVERT_ERROR,
+                            );
                         } else {
-                            expect(this.fillDebtOrder()).to.eventually.be.rejectedWith(REVERT_ERROR);
+                            expect(this.fillDebtOrder()).to.eventually.be.rejectedWith(
+                                REVERT_ERROR,
+                            );
                         }
                     });
                 } else {
                     it("should not emit a LogSimpleInterestTermStart event", async () => {
-                        const returnedLog = await this.getLogs(txHash, "LogSimpleInterestTermStart");
+                        const returnedLog = await this.getLogs(
+                            txHash,
+                            "LogSimpleInterestTermStart",
+                        );
 
                         expect(returnedLog).to.be.undefined;
                     });

--- a/test/ts/integration/examples/collateralized_simple_interest_terms_contract/runners/unpack_parameters_from_bytes.ts
+++ b/test/ts/integration/examples/collateralized_simple_interest_terms_contract/runners/unpack_parameters_from_bytes.ts
@@ -16,7 +16,9 @@ export class UnpackParametersFromBytesRunner {
         this.testScenario = this.testScenario.bind(this);
     }
 
-    public initialize(collateralizedSimpleInterestTermsContract: CollateralizedSimpleInterestTermsContractContract) {
+    public initialize(
+        collateralizedSimpleInterestTermsContract: CollateralizedSimpleInterestTermsContractContract,
+    ) {
         this.collateralizedSimpleInterestTermsContract = collateralizedSimpleInterestTermsContract;
     }
 

--- a/test/ts/integration/examples/collateralized_simple_interest_terms_contract/scenarios/index.ts
+++ b/test/ts/integration/examples/collateralized_simple_interest_terms_contract/scenarios/index.ts
@@ -1,7 +1,10 @@
 import { BigNumber } from "bignumber.js";
 import * as Units from "../../../../test_utils/units";
 
-import { SimpleInterestContractTerms, SimpleInterestParameters } from "../../../../factories/terms_contract_parameters";
+import {
+    SimpleInterestContractTerms,
+    SimpleInterestParameters,
+} from "../../../../factories/terms_contract_parameters";
 import { DummyTokenContract } from "../../../../../../types/generated/dummy_token";
 import { SignedDebtOrder } from "../../../../../../types/kernel/debt_order";
 
@@ -10,7 +13,7 @@ export const DEFAULT_REGISTER_TERM_START_ARGS = {
     // Our migrations set REP up to be at index 0 of the registry.
     principalTokenIndex: new BigNumber(0),
     principalAmount: Units.ether(1),
-    interestRate: new BigNumber(2500),
+    interestRateFixedPoint: Units.interestRateFixedPoint(2.5),
     amortizationUnitType: new BigNumber(1),
     termLengthUnits: new BigNumber(4),
     // Parameters for collateralization.
@@ -26,13 +29,14 @@ export const DEFAULT_REGISTER_TERM_START_ARGS = {
     permissionToCollateralize: true,
     succeeds: true,
     reverts: false,
-    termsContractParameters: (terms: SimpleInterestContractTerms) => SimpleInterestParameters.pack(terms),
+    termsContractParameters: (terms: SimpleInterestContractTerms) =>
+        SimpleInterestParameters.pack(terms),
 };
 
 export const DEFAULT_REGISTER_REPAYMENT_ARGS = {
     principalTokenIndex: new BigNumber(0),
     principalAmount: Units.ether(1),
-    interestRate: new BigNumber(2.5),
+    interestRateFixedPoint: Units.interestRateFixedPoint(2.5),
     amortizationUnitType: new BigNumber(1),
     termLengthUnits: new BigNumber(4),
     repaymentAmount: Units.ether(1.29),
@@ -45,7 +49,8 @@ export const DEFAULT_REGISTER_REPAYMENT_ARGS = {
     // Misc parameters.
     collateralTokenAllowance: Units.ether(0.005),
     collateralTokenBalance: Units.ether(0.005),
-    repaymentToken: (principalToken: DummyTokenContract, otherToken: DummyTokenContract) => principalToken,
+    repaymentToken: (principalToken: DummyTokenContract, otherToken: DummyTokenContract) =>
+        principalToken,
     debtOrder: (debtOrder: SignedDebtOrder) => debtOrder,
     repayFromRouter: true,
     succeeds: true,
@@ -59,8 +64,8 @@ export interface RegisterRepaymentScenario {
     principalTokenIndex: BigNumber;
     // The debt order's principal amount.
     principalAmount: BigNumber;
-    // The debt order's interest rate.
-    interestRate: BigNumber;
+    // The debt order's interest rate (in fixed point).
+    interestRateFixedPoint: BigNumber;
     // The index for amortization type, e.g. 0 for hourly, for debt order.
     amortizationUnitType: BigNumber;
     // The number of units of the given amortization type, e.g. 4 hours, for the debt order.
@@ -68,7 +73,10 @@ export interface RegisterRepaymentScenario {
     // The amount that the payer is attempting to repay.
     repaymentAmount: BigNumber;
     // The token used for repayments.
-    repaymentToken: (principalToken: DummyTokenContract, otherToken: DummyTokenContract) => DummyTokenContract;
+    repaymentToken: (
+        principalToken: DummyTokenContract,
+        otherToken: DummyTokenContract,
+    ) => DummyTokenContract;
     // The debt order to use in this scenario.
     debtOrder: (debtOrder: SignedDebtOrder) => SignedDebtOrder;
     debtorFee: BigNumber;
@@ -94,8 +102,8 @@ export interface RegisterTermStartScenario {
     principalTokenIndex: BigNumber;
     // The debt order's principal amount.
     principalAmount: BigNumber;
-    // The debt order's interest rate.
-    interestRate: BigNumber;
+    // The debt order's interest rate (in fixed point).
+    interestRateFixedPoint: BigNumber;
     // The index for amortization type, e.g. 0 for hourly, for debt order.
     amortizationUnitType: BigNumber;
     // The number of units of the given amortization type, e.g. 4 hours, for the debt order.

--- a/test/ts/integration/examples/collateralized_simple_interest_terms_contract/scenarios/successful_register_term_start.ts
+++ b/test/ts/integration/examples/collateralized_simple_interest_terms_contract/scenarios/successful_register_term_start.ts
@@ -10,14 +10,14 @@ export const SUCCESSFUL_REGISTER_TERM_START_SCENARIOS: RegisterTermStartScenario
         ...DEFAULT_REGISTER_TERM_START_ARGS,
     },
     {
-        description: "when the interest rate is 0",
+        description: "when the interest rate is 0%",
         ...DEFAULT_REGISTER_TERM_START_ARGS,
-        interestRate: new BigNumber(0),
+        interestRateFixedPoint: new BigNumber(0),
     },
     {
-        description: "when the interest rate is 100",
+        description: "when the interest rate is 100%",
         ...DEFAULT_REGISTER_TERM_START_ARGS,
-        interestRate: new BigNumber(100),
+        interestRateFixedPoint: Units.interestRateFixedPoint(100),
     },
     {
         description: "when the terms length is 0",

--- a/test/ts/integration/examples/collateralized_simple_interest_terms_contract/scenarios/unpack_parameters_from_bytes.ts
+++ b/test/ts/integration/examples/collateralized_simple_interest_terms_contract/scenarios/unpack_parameters_from_bytes.ts
@@ -9,46 +9,46 @@ import { UnpackParametersFromBytesScenario } from "./";
 const simpleTerms = {
     principalTokenIndex: new BigNumber(0),
     principalAmount: Units.ether(1),
-    interestRate: Units.percent(2.5),
+    interestRateFixedPoint: Units.interestRateFixedPoint(2.5),
     amortizationUnitType: new BigNumber(1),
     termLengthUnits: new BigNumber(4),
 };
 
 export const UNPACK_PARAMETERS_FROM_BYTES_SCENARIOS: UnpackParametersFromBytesScenario[] = [
     {
-        input: "0x00000000000de0b6b3a76400000009c410004000000000000000000000000000",
+        input: "0x00000000000de0b6b3a76400000061a810004000000000000000000000000000",
         expectedTerms: simpleTerms,
     },
     {
-        input: "0x01000000000de0b6b3a76400000009c410004000000000000000000000000000",
+        input: "0x01000000000de0b6b3a76400000061a810004000000000000000000000000000",
         expectedTerms: {
             ...simpleTerms,
             principalTokenIndex: new BigNumber(1),
         },
     },
     {
-        input: "0x00000000001bc16d674ec800000009c410004000000000000000000000000000",
+        input: "0x00000000001bc16d674ec800000061a810004000000000000000000000000000",
         expectedTerms: {
             ...simpleTerms,
             principalAmount: Units.ether(2),
         },
     },
     {
-        input: "0x00000000000de0b6b3a7640000000dac10004000000000000000000000000000",
+        input: "0x00000000000de0b6b3a76400000088b810004000000000000000000000000000",
         expectedTerms: {
             ...simpleTerms,
-            interestRate: Units.percent(3.5),
+            interestRateFixedPoint: Units.interestRateFixedPoint(3.5),
         },
     },
     {
-        input: "0x00000000000de0b6b3a76400000009c420004000000000000000000000000000",
+        input: "0x00000000000de0b6b3a76400000061a820004000000000000000000000000000",
         expectedTerms: {
             ...simpleTerms,
             amortizationUnitType: new BigNumber(2),
         },
     },
     {
-        input: "0x00000000000de0b6b3a76400000009c410005000000000000000000000000000",
+        input: "0x00000000000de0b6b3a76400000061a810005000000000000000000000000000",
         expectedTerms: {
             ...simpleTerms,
             termLengthUnits: new BigNumber(5),

--- a/test/ts/integration/examples/simple_interest_terms_contract/runners/register_term_start.ts
+++ b/test/ts/integration/examples/simple_interest_terms_contract/runners/register_term_start.ts
@@ -46,7 +46,7 @@ export class RegisterTermStartRunner extends SimpleInterestTermsContractRunner {
                         this.agreementId,
                         debtOrder.getPrincipalTokenAddress(),
                         debtOrder.getPrincipalAmount(),
-                        scenario.interestRate,
+                        scenario.interestRateFixedPoint,
                         scenario.amortizationUnitType,
                         scenario.termLengthUnits,
                     );
@@ -58,14 +58,21 @@ export class RegisterTermStartRunner extends SimpleInterestTermsContractRunner {
                 if (scenario.reverts) {
                     it("should revert the transaction", async () => {
                         if (!scenario.invokedByDebtKernel) {
-                            expect(this.registerTermsStart()).to.eventually.be.rejectedWith(REVERT_ERROR);
+                            expect(this.registerTermsStart()).to.eventually.be.rejectedWith(
+                                REVERT_ERROR,
+                            );
                         } else {
-                            expect(this.fillDebtOrder()).to.eventually.be.rejectedWith(REVERT_ERROR);
+                            expect(this.fillDebtOrder()).to.eventually.be.rejectedWith(
+                                REVERT_ERROR,
+                            );
                         }
                     });
                 } else {
                     it("should not emit a LogSimpleInterestTermStart event", async () => {
-                        const returnedLog = await this.getLogs(txHash, "LogSimpleInterestTermStart");
+                        const returnedLog = await this.getLogs(
+                            txHash,
+                            "LogSimpleInterestTermStart",
+                        );
 
                         expect(returnedLog).to.be.undefined;
                     });

--- a/test/ts/integration/examples/simple_interest_terms_contract/scenarios/index.ts
+++ b/test/ts/integration/examples/simple_interest_terms_contract/scenarios/index.ts
@@ -1,30 +1,35 @@
 import { BigNumber } from "bignumber.js";
 import * as Units from "../../../../test_utils/units";
 
-import { SimpleInterestContractTerms, SimpleInterestParameters } from "../../../../factories/terms_contract_parameters";
+import {
+    SimpleInterestContractTerms,
+    SimpleInterestParameters,
+} from "../../../../factories/terms_contract_parameters";
 import { DummyTokenContract } from "../../../../../../types/generated/dummy_token";
 import { SignedDebtOrder } from "../../../../../../types/kernel/debt_order";
 
 export const DEFAULT_REGISTER_TERM_START_ARGS = {
     principalTokenIndex: new BigNumber(0),
     principalAmount: Units.ether(1),
-    interestRate: Units.percent(2.5),
+    interestRateFixedPoint: Units.interestRateFixedPoint(2.5),
     amortizationUnitType: new BigNumber(1),
     termLengthUnits: new BigNumber(4),
     invokedByDebtKernel: true,
     succeeds: true,
     reverts: false,
-    termsContractParameters: (terms: SimpleInterestContractTerms) => SimpleInterestParameters.pack(terms),
+    termsContractParameters: (terms: SimpleInterestContractTerms) =>
+        SimpleInterestParameters.pack(terms),
 };
 
 export const DEFAULT_REGISTER_REPAYMENT_ARGS = {
     principalTokenIndex: new BigNumber(0),
     principalAmount: Units.ether(1),
-    interestRate: Units.percent(2.5),
+    interestRateFixedPoint: Units.interestRateFixedPoint(2.5),
     amortizationUnitType: new BigNumber(1),
     termLengthUnits: new BigNumber(4),
     repaymentAmount: Units.ether(1.29),
-    repaymentToken: (principalToken: DummyTokenContract, otherToken: DummyTokenContract) => principalToken,
+    repaymentToken: (principalToken: DummyTokenContract, otherToken: DummyTokenContract) =>
+        principalToken,
     debtOrder: (debtOrder: SignedDebtOrder) => debtOrder,
     repayFromRouter: true,
     succeeds: true,
@@ -38,8 +43,8 @@ export interface RegisterRepaymentScenario {
     principalTokenIndex: BigNumber;
     // The debt order's principal amount.
     principalAmount: BigNumber;
-    // The debt order's interest rate.
-    interestRate: BigNumber;
+    // The debt order's interest rate (in fixed point).
+    interestRateFixedPoint: BigNumber;
     // The index for amortization type, e.g. 0 for hourly, for debt order.
     amortizationUnitType: BigNumber;
     // The number of units of the given amortization type, e.g. 4 hours, for the debt order.
@@ -47,7 +52,10 @@ export interface RegisterRepaymentScenario {
     // The amount that the payer is attempting to repay.
     repaymentAmount: BigNumber;
     // The token used for repayments.
-    repaymentToken: (principalToken: DummyTokenContract, otherToken: DummyTokenContract) => DummyTokenContract;
+    repaymentToken: (
+        principalToken: DummyTokenContract,
+        otherToken: DummyTokenContract,
+    ) => DummyTokenContract;
     // The debt order to use in this scenario.
     debtOrder: (debtOrder: SignedDebtOrder) => SignedDebtOrder;
     // True if repayment gets logged.
@@ -65,8 +73,8 @@ export interface RegisterTermStartScenario {
     principalTokenIndex: BigNumber;
     // The debt order's principal amount.
     principalAmount: BigNumber;
-    // The debt order's interest rate.
-    interestRate: BigNumber;
+    // The debt order's interest rate (in fixed point).
+    interestRateFixedPoint: BigNumber;
     // The index for amortization type, e.g. 0 for hourly, for debt order.
     amortizationUnitType: BigNumber;
     // The number of units of the given amortization type, e.g. 4 hours, for the debt order.

--- a/test/ts/integration/examples/simple_interest_terms_contract/scenarios/successful_register_term_start.ts
+++ b/test/ts/integration/examples/simple_interest_terms_contract/scenarios/successful_register_term_start.ts
@@ -12,12 +12,12 @@ export const SUCCESSFUL_REGISTER_TERM_START_SCENARIOS: RegisterTermStartScenario
     {
         description: "when the interest rate is 0",
         ...DEFAULT_REGISTER_TERM_START_ARGS,
-        interestRate: Units.percent(0),
+        interestRateFixedPoint: Units.interestRateFixedPoint(0),
     },
     {
         description: "when the interest rate is 100",
         ...DEFAULT_REGISTER_TERM_START_ARGS,
-        interestRate: Units.percent(100),
+        interestRateFixedPoint: Units.interestRateFixedPoint(100),
     },
     {
         description: "when the terms length is 0",

--- a/test/ts/integration/examples/simple_interest_terms_contract/scenarios/unpack_parameters_from_bytes.ts
+++ b/test/ts/integration/examples/simple_interest_terms_contract/scenarios/unpack_parameters_from_bytes.ts
@@ -7,46 +7,46 @@ import { UnpackParametersFromBytesScenario } from "./";
 const defaultTerms = {
     principalTokenIndex: new BigNumber(0),
     principalAmount: Units.ether(1),
-    interestRate: Units.percent(2.5),
+    interestRateFixedPoint: Units.interestRateFixedPoint(2.5),
     amortizationUnitType: new BigNumber(1),
     termLengthUnits: new BigNumber(4),
 };
 
 export const UNPACK_PARAMETERS_FROM_BYTES_SCENARIOS: UnpackParametersFromBytesScenario[] = [
     {
-        input: "0x00000000000de0b6b3a76400000009c410004000000000000000000000000000",
+        input: "0x00000000000de0b6b3a76400000061a810004000000000000000000000000000",
         expectedTerms: defaultTerms,
     },
     {
-        input: "0x01000000000de0b6b3a76400000009c410004000000000000000000000000000",
+        input: "0x01000000000de0b6b3a76400000061a810004000000000000000000000000000",
         expectedTerms: {
             ...defaultTerms,
             principalTokenIndex: new BigNumber(1),
         },
     },
     {
-        input: "0x00000000001bc16d674ec800000009c410004000000000000000000000000000",
+        input: "0x00000000001bc16d674ec800000061a810004000000000000000000000000000",
         expectedTerms: {
             ...defaultTerms,
             principalAmount: Units.ether(2),
         },
     },
     {
-        input: "0x00000000000de0b6b3a7640000000dac10004000000000000000000000000000",
+        input: "0x00000000000de0b6b3a76400000088b810004000000000000000000000000000",
         expectedTerms: {
             ...defaultTerms,
-            interestRate: Units.percent(3.5),
+            interestRateFixedPoint: Units.interestRateFixedPoint(3.5),
         },
     },
     {
-        input: "0x00000000000de0b6b3a76400000009c420004000000000000000000000000000",
+        input: "0x00000000000de0b6b3a76400000061a820004000000000000000000000000000",
         expectedTerms: {
             ...defaultTerms,
             amortizationUnitType: new BigNumber(2),
         },
     },
     {
-        input: "0x00000000000de0b6b3a76400000009c410005000000000000000000000000000",
+        input: "0x00000000000de0b6b3a76400000061a810005000000000000000000000000000",
         expectedTerms: {
             ...defaultTerms,
             termLengthUnits: new BigNumber(5),

--- a/test/ts/integration/repayment_router.ts
+++ b/test/ts/integration/repayment_router.ts
@@ -96,7 +96,7 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
         const termsContractParameters = SimpleInterestParameters.pack({
             principalTokenIndex: new BigNumber(0), // Our migrations set REP up to be at index 0 of the registry
             principalAmount: Units.ether(1),
-            interestRate: Units.percent(2.5),
+            interestRateFixedPoint: Units.interestRateFixedPoint(2.5),
             amortizationUnitType: new BigNumber(1), // (weekly)
             termLengthUnits: new BigNumber(4),
         });
@@ -123,7 +123,7 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
             termsContractParameters,
             underwriter: UNDERWRITER,
             underwriterFee: Units.ether(0.0015),
-            underwriterRiskRating: Units.percent(1.35),
+            underwriterRiskRating: Units.underwriterRiskRatingFixedPoint(1.35),
         };
 
         orderFactory = new DebtOrderFactory(defaultOrderParams);

--- a/test/ts/test_utils/units.ts
+++ b/test/ts/test_utils/units.ts
@@ -1,11 +1,18 @@
 import { BigNumber } from "bignumber.js";
 import * as Web3 from "web3";
 
+const INTEREST_RATE_SCALING_FACTOR = new BigNumber(10 ** 4);
+const UNDERWRITER_RISK_RATING_SCALING_FACTOR = new BigNumber(10 ** 7);
+
 export function ether(amount: number): BigNumber {
     const weiString = web3.toWei(amount, "ether");
     return new BigNumber(weiString);
 }
 
-export function percent(amount: number): BigNumber {
-    return new BigNumber(amount).div(100).times(10 ** 5);
+export function interestRateFixedPoint(amount: number): BigNumber {
+    return new BigNumber(amount).times(INTEREST_RATE_SCALING_FACTOR);
+}
+
+export function underwriterRiskRatingFixedPoint(riskRating: number): BigNumber {
+    return new BigNumber(riskRating).times(UNDERWRITER_RISK_RATING_SCALING_FACTOR);
 }

--- a/test/ts/unit/collateralized_simple_interest_terms_contract.ts
+++ b/test/ts/unit/collateralized_simple_interest_terms_contract.ts
@@ -41,7 +41,7 @@ const collateralizerContract = artifacts.require("Collateralizer");
 // Collateral Amount: 0.005 REP
 // Grace Period: 20 Days
 const termsParamsWithCollateral =
-    "0x08000000000de0b6b3a76400000009c4200040000000000011c37937e0800014";
+    "0x08000000000de0b6b3a76400000061a8200040000000000011c37937e0800014";
 
 contract("CollateralizedSimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
     let termsContract: CollateralizedSimpleInterestTermsContractContract;
@@ -190,14 +190,14 @@ contract("CollateralizedSimpleInterestTermsContract (Unit Tests)", async (ACCOUN
         describe("agent who is DebtKernel calls registerTermStart", () => {
             const principalTokenIndex = new BigNumber(8); // token at index 8
             const principalAmount = Units.ether(1); // 1 ether.
-            const interestRate = Units.percent(2.5); // 2.5% interest rate.
+            const interestRateFixedPoint = Units.interestRateFixedPoint(2.5); // 2.5% interest rate.
             const amortizationUnitType = new BigNumber(2); // unit code for weeks.
             const termLengthUnits = new BigNumber(4); // term is for 4 weeks.
 
             const termsParams = SimpleInterestParameters.pack({
                 principalTokenIndex,
                 principalAmount,
-                interestRate,
+                interestRateFixedPoint,
                 amortizationUnitType,
                 termLengthUnits,
             });
@@ -262,7 +262,7 @@ contract("CollateralizedSimpleInterestTermsContract (Unit Tests)", async (ACCOUN
                         const invalidTermsParams = SimpleInterestParameters.pack({
                             principalTokenIndex,
                             principalAmount,
-                            interestRate,
+                            interestRateFixedPoint,
                             // Invalid value for the amortizationUnitType.
                             amortizationUnitType: new BigNumber(5),
                             termLengthUnits,
@@ -326,7 +326,7 @@ contract("CollateralizedSimpleInterestTermsContract (Unit Tests)", async (ACCOUN
                             ARBITRARY_AGREEMENT_ID,
                             mockToken.address,
                             principalAmount,
-                            interestRate,
+                            interestRateFixedPoint,
                             amortizationUnitType,
                             termLengthUnits,
                         ),
@@ -356,14 +356,14 @@ contract("CollateralizedSimpleInterestTermsContract (Unit Tests)", async (ACCOUN
             before(async () => {
                 const principalTokenIndex = new BigNumber(0);
                 const principalAmount = Units.ether(1);
-                const interestRate = Units.percent(1);
+                const interestRateFixedPoint = Units.interestRateFixedPoint(1);
                 const amortizationUnitType = new BigNumber(0);
                 const termLengthUnits = new BigNumber(3);
 
                 const termsContractParameters = SimpleInterestParameters.pack({
                     principalTokenIndex,
                     principalAmount,
-                    interestRate,
+                    interestRateFixedPoint,
                     amortizationUnitType,
                     termLengthUnits,
                 });
@@ -468,14 +468,14 @@ contract("CollateralizedSimpleInterestTermsContract (Unit Tests)", async (ACCOUN
 
             const principalTokenIndex = new BigNumber(2); // token at index 2 of token registry.
             const principalAmount = Units.ether(100); // 100 ether.
-            const interestRate = Units.percent(1); // 1% interest rate.
+            const interestRateFixedPoint = Units.interestRateFixedPoint(1); // 1% interest rate.
             const amortizationUnitType = new BigNumber(2); // unit code for weeks.
             const termLengthUnits = new BigNumber(10); // term is for 10 weeks.
 
             const inputParamsAsHex = SimpleInterestParameters.pack({
                 principalTokenIndex,
                 principalAmount,
-                interestRate,
+                interestRateFixedPoint,
                 amortizationUnitType,
                 termLengthUnits,
             });
@@ -542,14 +542,14 @@ contract("CollateralizedSimpleInterestTermsContract (Unit Tests)", async (ACCOUN
     describe("#unpackParametersFromBytes", () => {
         const principalTokenIndex = new BigNumber(6); // token at index 6 of token registry.
         const principalAmount = Units.ether(200); // 200 ether.
-        const interestRate = Units.percent(1.5); // 1.5% interest rate.
+        const interestRateFixedPoint = Units.interestRateFixedPoint(1.5); // 1.5% interest rate.
         const amortizationUnitType = new BigNumber(4); // unit code for years.
         const termLengthUnits = new BigNumber(10); // term is for 10 years.
 
         const inputParamsAsHex = SimpleInterestParameters.pack({
             principalTokenIndex,
             principalAmount,
-            interestRate,
+            interestRateFixedPoint,
             amortizationUnitType,
             termLengthUnits,
         });
@@ -558,14 +558,14 @@ contract("CollateralizedSimpleInterestTermsContract (Unit Tests)", async (ACCOUN
             const [
                 unpackedPrincipalTokenIndex,
                 unpackedPrincipalAmount,
-                unpackedInterestRate,
+                unpackedFixedPointInterestRate,
                 unpackedAmortizationUnitType,
                 unpackedTermLength,
             ] = await termsContract.unpackParametersFromBytes.callAsync(inputParamsAsHex);
 
             expect(unpackedPrincipalTokenIndex).to.bignumber.equal(principalTokenIndex);
             expect(unpackedPrincipalAmount).to.bignumber.equal(principalAmount);
-            expect(unpackedInterestRate).to.bignumber.equal(interestRate);
+            expect(unpackedFixedPointInterestRate).to.bignumber.equal(interestRateFixedPoint);
             expect(unpackedAmortizationUnitType).to.bignumber.equal(amortizationUnitType);
             expect(unpackedTermLength).to.bignumber.equal(termLengthUnits);
         });
@@ -593,14 +593,14 @@ contract("CollateralizedSimpleInterestTermsContract (Unit Tests)", async (ACCOUN
         describe("when termsContractParameters associated w/ debt agreement malformed", () => {
             const principalTokenIndex = new BigNumber(0);
             const principalAmount = Units.ether(10);
-            const interestRate = Units.percent(1);
+            const interestRateFixedPoint = Units.interestRateFixedPoint(1);
             const amortizationUnitType = new BigNumber(10); // invalid unit code.
             const termLengthUnits = new BigNumber(10);
 
             const invalidTermsParams = SimpleInterestParameters.pack({
                 principalTokenIndex,
                 principalAmount,
-                interestRate,
+                interestRateFixedPoint,
                 amortizationUnitType,
                 termLengthUnits,
             });
@@ -644,14 +644,15 @@ contract("CollateralizedSimpleInterestTermsContract (Unit Tests)", async (ACCOUN
             */
             const principalTokenIndex = new BigNumber(0); // arbitrary index for principal token in registry
             const principalAmount = Units.ether(12); // 12 ether principal.
-            const interestRate = Units.percent(1); // 1% interest rate.
+            const interestRateDecimalPercentage = 1; // 1% interest rate (decimal percentage).
+            const interestRateFixedPoint = Units.interestRateFixedPoint(1); // 1% interest rate (fixed point).
             const amortizationUnitType = new BigNumber(4); // unit code for years.
             const termLengthUnits = new BigNumber(3); // term is three years.
 
             const validTermsParams = SimpleInterestParameters.pack({
                 principalTokenIndex,
                 principalAmount,
-                interestRate,
+                interestRateFixedPoint,
                 amortizationUnitType,
                 termLengthUnits,
             });
@@ -659,17 +660,15 @@ contract("CollateralizedSimpleInterestTermsContract (Unit Tests)", async (ACCOUN
             const ORIGIN_MOMENT = moment();
             const BLOCK_ISSUANCE_TIMESTAMP = ORIGIN_MOMENT.unix();
 
+            const PERCENTAGE_SCALING_FACTOR = 100;
+
             const ZERO_AMOUNT = Units.ether(0);
             let INSTALLMENT_AMOUNT: BigNumber;
             let FULL_AMOUNT: BigNumber;
 
             before(async () => {
-                const INTEREST_RATE_SCALING_FACTOR = await termsContract.INTEREST_RATE_SCALING_FACTOR.callAsync();
-                const PERCENTAGE_SCALING_FACTOR = await termsContract.PERCENTAGE_SCALING_FACTOR.callAsync();
-
                 const TOTAL_INTEREST = principalAmount
-                    .mul(interestRate)
-                    .div(INTEREST_RATE_SCALING_FACTOR)
+                    .mul(interestRateDecimalPercentage)
                     .div(PERCENTAGE_SCALING_FACTOR);
 
                 FULL_AMOUNT = principalAmount.add(TOTAL_INTEREST);

--- a/test/ts/unit/collateralized_simple_interest_terms_contract.ts
+++ b/test/ts/unit/collateralized_simple_interest_terms_contract.ts
@@ -665,10 +665,12 @@ contract("CollateralizedSimpleInterestTermsContract (Unit Tests)", async (ACCOUN
 
             before(async () => {
                 const INTEREST_RATE_SCALING_FACTOR = await termsContract.INTEREST_RATE_SCALING_FACTOR.callAsync();
+                const PERCENTAGE_SCALING_FACTOR = await termsContract.PERCENTAGE_SCALING_FACTOR.callAsync();
 
                 const TOTAL_INTEREST = principalAmount
                     .mul(interestRate)
-                    .div(INTEREST_RATE_SCALING_FACTOR);
+                    .div(INTEREST_RATE_SCALING_FACTOR)
+                    .div(PERCENTAGE_SCALING_FACTOR);
 
                 FULL_AMOUNT = principalAmount.add(TOTAL_INTEREST);
 

--- a/test/ts/unit/debt_kernel.ts
+++ b/test/ts/unit/debt_kernel.ts
@@ -149,7 +149,7 @@ contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
             termsContractParameters: TERMS_CONTRACT_PARAMETERS,
             underwriter: UNDERWRITER,
             underwriterFee: Units.ether(0.0015),
-            underwriterRiskRating: Units.percent(1.35),
+            underwriterRiskRating: Units.underwriterRiskRatingFixedPoint(1.35),
         };
 
         orderFactory = new DebtOrderFactory(defaultOrderParams);

--- a/test/ts/unit/debt_registry.ts
+++ b/test/ts/unit/debt_registry.ts
@@ -95,7 +95,7 @@ contract("Debt Registry (Unit Tests)", async (ACCOUNTS) => {
                 termsContract: TERMS_CONTRACT_ADDRESS,
                 termsContractParameters: ARBITRARY_TERMS_CONTRACT_PARAMS,
                 underwriter: UNDERWRITER,
-                underwriterRiskRating: Units.percent(5),
+                underwriterRiskRating: Units.underwriterRiskRatingFixedPoint(5),
                 version: VERSION,
             });
         };

--- a/test/ts/unit/debt_token.ts
+++ b/test/ts/unit/debt_token.ts
@@ -110,7 +110,7 @@ contract("Debt Token (Unit Tests)", (ACCOUNTS) => {
                 termsContract: TERMS_CONTRACT_ADDRESS,
                 termsContractParameters: ARBITRARY_TERMS_CONTRACT_PARAMS[i],
                 underwriter: UNDERWRITERS[i],
-                underwriterRiskRating: Units.percent(3.4),
+                underwriterRiskRating: Units.underwriterRiskRatingFixedPoint(3.4),
                 version: repaymentRouterContractInstance.address,
             });
         });

--- a/test/ts/unit/simple_interest_terms_contract.ts
+++ b/test/ts/unit/simple_interest_terms_contract.ts
@@ -146,14 +146,14 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
         describe("agent who is DebtKernel calls registerTermStart", () => {
             const principalTokenIndex = new BigNumber(8); // token at index 8
             const principalAmount = Units.ether(1); // 1 ether.
-            const interestRate = Units.percent(2.5); // 2.5% interest rate.
+            const interestRateFixedPoint = Units.interestRateFixedPoint(2.5); // 2.5% interest rate.
             const amortizationUnitType = new BigNumber(2); // unit code for weeks.
             const termLengthUnits = new BigNumber(4); // term is for 4 weeks.
 
             const termsParams = SimpleInterestParameters.pack({
                 principalTokenIndex,
                 principalAmount,
-                interestRate,
+                interestRateFixedPoint,
                 amortizationUnitType,
                 termLengthUnits,
             });
@@ -220,7 +220,7 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
                         const invalidTermsParams = SimpleInterestParameters.pack({
                             principalTokenIndex,
                             principalAmount,
-                            interestRate,
+                            interestRateFixedPoint,
                             // Invalid value for the amortizationUnitType
                             amortizationUnitType: new BigNumber(5),
                             termLengthUnits,
@@ -285,7 +285,7 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
                             ARBITRARY_AGREEMENT_ID,
                             mockToken.address,
                             principalAmount,
-                            interestRate,
+                            interestRateFixedPoint,
                             amortizationUnitType,
                             termLengthUnits,
                         ),
@@ -315,14 +315,14 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
             before(async () => {
                 const principalTokenIndex = new BigNumber(0);
                 const principalAmount = Units.ether(1);
-                const interestRate = Units.percent(1);
+                const interestRateFixedPoint = Units.interestRateFixedPoint(1);
                 const amortizationUnitType = new BigNumber(0);
                 const termLengthUnits = new BigNumber(3);
 
                 const termsContractParameters = SimpleInterestParameters.pack({
                     principalTokenIndex,
                     principalAmount,
-                    interestRate,
+                    interestRateFixedPoint,
                     amortizationUnitType,
                     termLengthUnits,
                 });
@@ -423,14 +423,15 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
 
             const principalTokenIndex = new BigNumber(2); // token at index 2 of token registry.
             const principalAmount = Units.ether(100); // 100 ether.
-            const interestRate = Units.percent(1); // 1% interest rate.
+            const interestRate = 1.0; // 1% interest rate (decimal)
+            const interestRateFixedPoint = Units.interestRateFixedPoint(interestRate); // 1% interest rate (fixed point)
             const amortizationUnitType = new BigNumber(2); // unit code for weeks.
             const termLengthUnits = new BigNumber(10); // term is for 10 weeks.
 
             const inputParamsAsHex = SimpleInterestParameters.pack({
                 principalTokenIndex,
                 principalAmount,
-                interestRate,
+                interestRateFixedPoint,
                 amortizationUnitType,
                 termLengthUnits,
             });
@@ -497,14 +498,14 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
     describe("#unpackParametersFromBytes", () => {
         const principalTokenIndex = new BigNumber(6); // token at index 6 of token registry.
         const principalAmount = Units.ether(200); // 200 ether.
-        const interestRate = Units.percent(1.5); // 1.5% interest rate.
+        const interestRateFixedPoint = Units.interestRateFixedPoint(1.5); // 1.5% interest rate (fixed point).
         const amortizationUnitType = new BigNumber(4); // unit code for years.
         const termLengthUnits = new BigNumber(10); // term is for 10 years.
 
         const inputParamsAsHex = SimpleInterestParameters.pack({
             principalTokenIndex,
             principalAmount,
-            interestRate,
+            interestRateFixedPoint,
             amortizationUnitType,
             termLengthUnits,
         });
@@ -513,14 +514,14 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
             const [
                 unpackedPrincipalTokenIndex,
                 unpackedPrincipalAmount,
-                unpackedInterestRate,
+                unpackedFixedPointInterestRate,
                 unpackedAmortizationUnitType,
                 unpackedTermLength,
             ] = await termsContract.unpackParametersFromBytes.callAsync(inputParamsAsHex);
 
             expect(unpackedPrincipalTokenIndex).to.bignumber.equal(principalTokenIndex);
             expect(unpackedPrincipalAmount).to.bignumber.equal(principalAmount);
-            expect(unpackedInterestRate).to.bignumber.equal(interestRate);
+            expect(unpackedFixedPointInterestRate).to.bignumber.equal(interestRateFixedPoint);
             expect(unpackedAmortizationUnitType).to.bignumber.equal(amortizationUnitType);
             expect(unpackedTermLength).to.bignumber.equal(termLengthUnits);
         });
@@ -548,14 +549,14 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
         describe("when termsContractParameters associated w/ debt agreement malformed", () => {
             const principalTokenIndex = new BigNumber(0);
             const principalAmount = Units.ether(10);
-            const interestRate = Units.percent(1);
+            const interestRateFixedPoint = Units.interestRateFixedPoint(1);
             const amortizationUnitType = new BigNumber(10); // invalid unit code.
             const termLengthUnits = new BigNumber(10);
 
             const invalidTermsParams = SimpleInterestParameters.pack({
                 principalTokenIndex,
                 principalAmount,
-                interestRate,
+                interestRateFixedPoint,
                 amortizationUnitType,
                 termLengthUnits,
             });
@@ -599,17 +600,20 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
             */
             const principalTokenIndex = new BigNumber(0); // arbitrary index for principal token in registry
             const principalAmount = Units.ether(12); // 12 ether principal.
-            const interestRate = Units.percent(1); // 1% interest rate.
+            const interestRateDecimalPercentage = 1; // 1% interest rate (decimal percentage).
+            const interestRateFixedPoint = Units.interestRateFixedPoint(1); // 1% interest rate (fixed point).
             const amortizationUnitType = new BigNumber(4); // unit code for years.
             const termLengthUnits = new BigNumber(3); // term is three years.
 
             const validTermsParams = SimpleInterestParameters.pack({
                 principalTokenIndex,
                 principalAmount,
-                interestRate,
+                interestRateFixedPoint,
                 amortizationUnitType,
                 termLengthUnits,
             });
+
+            const PERCENTAGE_SCALING_FACTOR = 100;
 
             const ORIGIN_MOMENT = moment();
             const BLOCK_ISSUANCE_TIMESTAMP = ORIGIN_MOMENT.unix();
@@ -619,12 +623,8 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
             let FULL_AMOUNT: BigNumber;
 
             before(async () => {
-                const INTEREST_RATE_SCALING_FACTOR = await termsContract.INTEREST_RATE_SCALING_FACTOR.callAsync();
-                const PERCENTAGE_SCALING_FACTOR = await termsContract.PERCENTAGE_SCALING_FACTOR.callAsync();
-
                 const TOTAL_INTEREST = principalAmount
-                    .mul(interestRate)
-                    .div(INTEREST_RATE_SCALING_FACTOR)
+                    .mul(interestRateDecimalPercentage)
                     .div(PERCENTAGE_SCALING_FACTOR);
 
                 FULL_AMOUNT = principalAmount.add(TOTAL_INTEREST);

--- a/test/ts/unit/simple_interest_terms_contract.ts
+++ b/test/ts/unit/simple_interest_terms_contract.ts
@@ -620,10 +620,12 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
 
             before(async () => {
                 const INTEREST_RATE_SCALING_FACTOR = await termsContract.INTEREST_RATE_SCALING_FACTOR.callAsync();
+                const PERCENTAGE_SCALING_FACTOR = await termsContract.PERCENTAGE_SCALING_FACTOR.callAsync();
 
                 const TOTAL_INTEREST = principalAmount
                     .mul(interestRate)
-                    .div(INTEREST_RATE_SCALING_FACTOR);
+                    .div(INTEREST_RATE_SCALING_FACTOR)
+                    .div(PERCENTAGE_SCALING_FACTOR);
 
                 FULL_AMOUNT = principalAmount.add(TOTAL_INTEREST);
 


### PR DESCRIPTION
*This PR introduces the following changes*:

- scale down interest amount calculation by a `PERCENTAGE_SCALING_FACTOR` of 100
- Fix tests to account for this.

## Motivation
Alex of Confirmation Labs reported a bug in which `getExpectedRepaymentValue` on `SimpleInterestTermsContract` returned a value which did not seem in line with how interest rate calculations ought to occur -- namely, a principal amount of 2 ETH w/ an interest rate of 1% would return a total expected repayment amount of 4 ETH.   It turns out he ran into a *very* important idiosyncrasy -- our interest rate calculations don't account for the fact that interest percentages have an implicit denominator of 100, i.e. `1% = 1/100`.  Our test suite for `charta` didn't catch this because it calculates `TOTAL_INTEREST` using the same math in the contracts, and, similarly, our test suite for `dharma.js` didn't catch this because it delegates interest calculations to the `TermsContract` through `getExpectedRepaymentValue`. 