### PR TITLE
separation of interest rate scaling factors for PERCENT and MULTIPLIER format

### DIFF
--- a/contracts/examples/SimpleInterestTermsContract.sol
+++ b/contracts/examples/SimpleInterestTermsContract.sol
@@ -32,11 +32,28 @@ contract SimpleInterestTermsContract is TermsContract {
 
     struct SimpleInterestParams {
         address principalTokenAddress;
+
         uint principalAmount;
+
+        // This field contains an encoded interest rate of the debt.
+        //
+        // To get an interest rate in the multiplier format, you need to
+        // divide it by INTEREST_RATE_SCALING_FACTOR_MULTIPLIER.
+        // For example for 1% interest rate (0.01 in the multiplier format)
+        // this field will contain 0.01 * INTEREST_RATE_SCALING_FACTOR_MULTIPLIER = 10'000.
+        // 
+        // To get an interest rate in the percent format, you need to
+        // divide it by INTEREST_RATE_SCALING_FACTOR_PERCENT.
+        // For example for 1% interest rate (1 in the percent format)
+        // this field will contain 1 * INTEREST_RATE_SCALING_FACTOR_PERCENT = 10'000.
         uint interestRate;
+
         uint termStartUnixTimestamp;
+
         uint termEndUnixTimestamp;
+
         AmortizationUnitType amortizationUnitType;
+
         uint termLengthInAmortizationUnits;
     }
 
@@ -46,10 +63,8 @@ contract SimpleInterestTermsContract is TermsContract {
     uint public constant MONTH_LENGTH_IN_SECONDS = DAY_LENGTH_IN_SECONDS * 30;
     uint public constant YEAR_LENGTH_IN_SECONDS = DAY_LENGTH_IN_SECONDS * 365;
 
-    // Given that Solidity doesn't support floating points, we represent
-    // decimal values (such as interestRate) with fixed point values
-    // scaled up by a factor of 10000 -- e.g. 10.342% => 1034250
-    uint public constant INTEREST_RATE_SCALING_FACTOR = 10 ** 4;
+    uint public constant INTEREST_RATE_SCALING_FACTOR_PERCENT = 10 ** 4;
+    uint public constant INTEREST_RATE_SCALING_FACTOR_MULTIPLIER = INTEREST_RATE_SCALING_FACTOR_PERCENT * 100;
 
     mapping (bytes32 => uint) public valueRepaid;
 
@@ -351,7 +366,7 @@ contract SimpleInterestTermsContract is TermsContract {
         // by the scaling factor we choose for interest rates.
         uint totalInterest = params.principalAmount
             .mul(params.interestRate)
-            .div(INTEREST_RATE_SCALING_FACTOR);
+            .div(INTEREST_RATE_SCALING_FACTOR_MULTIPLIER);
 
         return params.principalAmount.add(totalInterest);
     }

--- a/test/ts/unit/collateralized_simple_interest_terms_contract.ts
+++ b/test/ts/unit/collateralized_simple_interest_terms_contract.ts
@@ -664,11 +664,11 @@ contract("CollateralizedSimpleInterestTermsContract (Unit Tests)", async (ACCOUN
             let FULL_AMOUNT: BigNumber;
 
             before(async () => {
-                const INTEREST_RATE_SCALING_FACTOR = await termsContract.INTEREST_RATE_SCALING_FACTOR.callAsync();
+                const INTEREST_RATE_SCALING_FACTOR_MULTIPLIER = await termsContract.INTEREST_RATE_SCALING_FACTOR_MULTIPLIER.callAsync();
 
                 const TOTAL_INTEREST = principalAmount
                     .mul(interestRate)
-                    .div(INTEREST_RATE_SCALING_FACTOR);
+                    .div(INTEREST_RATE_SCALING_FACTOR_MULTIPLIER);
 
                 FULL_AMOUNT = principalAmount.add(TOTAL_INTEREST);
 

--- a/test/ts/unit/simple_interest_terms_contract.ts
+++ b/test/ts/unit/simple_interest_terms_contract.ts
@@ -619,11 +619,11 @@ contract("SimpleInterestTermsContract (Unit Tests)", async (ACCOUNTS) => {
             let FULL_AMOUNT: BigNumber;
 
             before(async () => {
-                const INTEREST_RATE_SCALING_FACTOR = await termsContract.INTEREST_RATE_SCALING_FACTOR.callAsync();
+                const INTEREST_RATE_SCALING_FACTOR_MULTIPLIER = await termsContract.INTEREST_RATE_SCALING_FACTOR_MULTIPLIER.callAsync();
 
                 const TOTAL_INTEREST = principalAmount
                     .mul(interestRate)
-                    .div(INTEREST_RATE_SCALING_FACTOR);
+                    .div(INTEREST_RATE_SCALING_FACTOR_MULTIPLIER);
 
                 FULL_AMOUNT = principalAmount.add(TOTAL_INTEREST);
 


### PR DESCRIPTION
In order to resolve ambiguity in which format interest rate is stored, we propose to have a convenient way to convert interest rate to both formats: percent and multiplier.
We introduce two different scaling factors:
- INTEREST_RATE_SCALING_FACTOR_PERCENT = 10^4 for conversion of interest rate into percent format
- INTEREST_RATE_SCALING_FACTOR_MULTIPLIER = 10^6 for conversion of interest rate into multiplier format 