### PR TITLE
build: re-compile contracts on deploy:kovan / deploy:development

### DIFF
--- a/scripts/deploy_development.sh
+++ b/scripts/deploy_development.sh
@@ -21,6 +21,9 @@
 rm build/contracts/*
 cp artifacts/json/* build/contracts/
 
+# Re-compile all contracts
+truffle compile --all
+
 # Deploy contracts onto development network
 truffle migrate --network development
 

--- a/scripts/deploy_kovan.sh
+++ b/scripts/deploy_kovan.sh
@@ -21,6 +21,9 @@ ssh -f -o 'ServerAliveInterval 10' -o 'ServerAliveCountMax 3' \
 # Grab PID of ssh connection process
 SSH_PID=$(ps aux | grep "ssh" | grep -v 'grep' | awk '{print $2}')
 
+# Re-compile all contracts
+truffle compile --all
+
 # Deploy contracts onto Kovan network
 truffle migrate --network kovan
 


### PR DESCRIPTION
This PR introduces the following changes:

 - We explicitly re-compile all contracts before deploying them to any network using the `deploy` scripts.  We were implicitly doing this before via the `truffle migrate` command, but `truffle migrate` selectively only re-compiles contracts it _thinks_ have been updated depending on a naive diff -- this causes problems in many scenarios, most notably if a parent in an inheritence tree has been modified but its child contract has not been modified.   Thus, we need to explicitly re-compile *all* contracts before deploying them to any given network.