### PR TITLE
build: make zeppelin's verison fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lint"
   ],
   "dependencies": {
-    "zeppelin-solidity": "^1.8.0"
+    "zeppelin-solidity": "1.8.0"
   },
   "devDependencies": {
     "@0xproject/abi-gen": "0.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5588,7 +5588,7 @@ yeoman-generator@^2.0.3:
     through2 "^2.0.0"
     yeoman-environment "^2.0.5"
 
-zeppelin-solidity@^1.8.0:
+zeppelin-solidity@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/zeppelin-solidity/-/zeppelin-solidity-1.8.0.tgz#049fcde7daea9fc85210f8c6db9f8cd1ab8a853a"
   dependencies:


### PR DESCRIPTION
This PR introduces the following changes:

 - Fix OpenZeppelin's version v1.8.0