### PR TITLE
Patch tests that rely on outdated assumptions

### DIFF
--- a/test/ts/integration/debt_kernel.ts
+++ b/test/ts/integration/debt_kernel.ts
@@ -124,7 +124,7 @@ contract("Debt Kernel (Integration Tests)", async (ACCOUNTS) => {
             termLengthUnits: new BigNumber(4), // Term length in amortization units.
         });
 
-        const latestBlockTime = await web3Utils.getCurrentBlockTime();
+        const latestBlockTime = await web3Utils.getLatestBlockTime();
 
         defaultOrderParams = {
             creditor: CREDITOR_1,

--- a/test/ts/integration/debt_kernel.ts
+++ b/test/ts/integration/debt_kernel.ts
@@ -14,6 +14,7 @@ import {
 } from "../test_utils/multisig";
 import ChaiSetup from "../test_utils/chai_setup";
 import { BigNumberSetup } from "../test_utils/bignumber_setup";
+import { Web3Utils } from "../../../utils/web3_utils";
 
 // Types
 import { SignedDebtOrder } from "../../../types/kernel/debt_order";
@@ -50,6 +51,9 @@ BigNumberSetup.configure();
 // Set up Chai
 ChaiSetup.configure();
 const expect = chai.expect;
+
+// Set up utils
+const web3Utils = new Web3Utils(web3);
 
 const debtKernelContract = artifacts.require("DebtKernel");
 
@@ -120,6 +124,8 @@ contract("Debt Kernel (Integration Tests)", async (ACCOUNTS) => {
             termLengthUnits: new BigNumber(4), // Term length in amortization units.
         });
 
+        const latestBlockTime = await web3Utils.getCurrentBlockTime();
+
         defaultOrderParams = {
             creditor: CREDITOR_1,
             creditorFee: Units.ether(0.002),
@@ -129,8 +135,9 @@ contract("Debt Kernel (Integration Tests)", async (ACCOUNTS) => {
             debtor: DEBTOR_1,
             debtorFee: Units.ether(0.001),
             expirationTimestampInSec: new BigNumber(
-                moment()
-                    .add(1, "days")
+                moment
+                    .unix(latestBlockTime)
+                    .add(30, "days")
                     .unix(),
             ),
             issuanceVersion: repaymentRouter.address,

--- a/test/ts/integration/examples/collateralized_simple_interest_terms_contract/collateralized_simple_interest_terms_contract.ts
+++ b/test/ts/integration/examples/collateralized_simple_interest_terms_contract/collateralized_simple_interest_terms_contract.ts
@@ -27,7 +27,11 @@ import { UNSUCCESSFUL_REGISTER_TERM_START_SCENARIOS } from "./scenarios/unsucces
 import { UNPACK_PARAMETERS_FROM_BYTES_SCENARIOS } from "./scenarios/unpack_parameters_from_bytes";
 
 // Scenario Runners
-import { RegisterRepaymentRunner, RegisterTermStartRunner, UnpackParametersFromBytesRunner } from "./runners";
+import {
+    RegisterRepaymentRunner,
+    RegisterTermStartRunner,
+    UnpackParametersFromBytesRunner,
+} from "./runners";
 
 contract("Collateralized Simple Interest Terms Contract (Integration Tests)", async (ACCOUNTS) => {
     let kernel: DebtKernelContract;
@@ -40,6 +44,7 @@ contract("Collateralized Simple Interest Terms Contract (Integration Tests)", as
     let collateralizerContract: CollateralizerContract;
 
     let dummyREPToken: DummyTokenContract;
+    let dummyZRXToken: DummyTokenContract;
 
     const CONTRACT_OWNER = ACCOUNTS[0];
     const DEBTOR_1 = ACCOUNTS[5];
@@ -49,8 +54,8 @@ contract("Collateralized Simple Interest Terms Contract (Integration Tests)", as
 
     const TX_DEFAULTS = { from: CONTRACT_OWNER, gas: 4712388 };
 
-    const registerRepaymentRunner = new RegisterRepaymentRunner();
-    const registerTermStartRunner = new RegisterTermStartRunner();
+    const registerRepaymentRunner = new RegisterRepaymentRunner(web3);
+    const registerTermStartRunner = new RegisterTermStartRunner(web3);
     const unpackParametersFromBytes = new UnpackParametersFromBytesRunner();
 
     before(async () => {
@@ -59,8 +64,12 @@ contract("Collateralized Simple Interest Terms Contract (Integration Tests)", as
         const dummyREPTokenAddress = await dummyTokenRegistryContract.getTokenAddressBySymbol.callAsync(
             "REP",
         );
+        const dummyZRXTokenAddress = await dummyTokenRegistryContract.getTokenAddressBySymbol.callAsync(
+            "ZRX",
+        );
 
         dummyREPToken = await DummyTokenContract.at(dummyREPTokenAddress, web3, TX_DEFAULTS);
+        dummyZRXToken = await DummyTokenContract.at(dummyZRXTokenAddress, web3, TX_DEFAULTS);
 
         debtTokenContract = await DebtTokenContract.deployed(web3, TX_DEFAULTS);
         debtRegistryContract = await DebtRegistryContract.deployed(web3, TX_DEFAULTS);
@@ -77,9 +86,7 @@ contract("Collateralized Simple Interest Terms Contract (Integration Tests)", as
         kernel = await DebtKernelContract.deployed(web3, TX_DEFAULTS);
 
         repaymentRouter = await RepaymentRouterContract.deployed(web3, TX_DEFAULTS);
-    });
 
-    before(() => {
         const testAccounts = {
             UNDERWRITER,
             CONTRACT_OWNER,
@@ -93,6 +100,7 @@ contract("Collateralized Simple Interest Terms Contract (Integration Tests)", as
             tokenTransferProxy,
             kernel,
             dummyREPToken,
+            dummyZRXToken,
             collateralizedSimpleInterestTermsContract,
             repaymentRouter,
             dummyTokenRegistryContract,
@@ -110,7 +118,9 @@ contract("Collateralized Simple Interest Terms Contract (Integration Tests)", as
         });
 
         describe("Unsuccessful register term start", () => {
-            UNSUCCESSFUL_REGISTER_TERM_START_SCENARIOS.forEach(registerTermStartRunner.testScenario);
+            UNSUCCESSFUL_REGISTER_TERM_START_SCENARIOS.forEach(
+                registerTermStartRunner.testScenario,
+            );
         });
     });
 

--- a/test/ts/integration/examples/collateralized_simple_interest_terms_contract/runners/collateralized_simple_interest_terms_contract.ts
+++ b/test/ts/integration/examples/collateralized_simple_interest_terms_contract/runners/collateralized_simple_interest_terms_contract.ts
@@ -87,11 +87,11 @@ export abstract class CollateralizedSimpleInterestTermsContractRunner {
 
         const { DEBTOR_1, CREDITOR_1, UNDERWRITER, RELAYER } = this.accounts;
 
-        const collateralTokenIndex = await dummyTokenRegistryContract.getTokenIndexBySymbol.callAsync(
-            "ZRX",
-        );
         const principalTokenIndex = await dummyTokenRegistryContract.getTokenIndexBySymbol.callAsync(
             "REP",
+        );
+        const collateralTokenIndex = await dummyTokenRegistryContract.getTokenIndexBySymbol.callAsync(
+            "ZRX",
         );
         const nonExistentTokenIndex = new BigNumber(99);
 
@@ -114,7 +114,7 @@ export abstract class CollateralizedSimpleInterestTermsContractRunner {
             },
         );
 
-        const latestBlockTime = await this.web3Utils.getCurrentBlockTime();
+        const latestBlockTime = await this.web3Utils.getLatestBlockTime();
 
         const defaultOrderParams = {
             creditor: CREDITOR_1,

--- a/test/ts/integration/examples/collateralized_simple_interest_terms_contract/runners/collateralized_simple_interest_terms_contract.ts
+++ b/test/ts/integration/examples/collateralized_simple_interest_terms_contract/runners/collateralized_simple_interest_terms_contract.ts
@@ -4,7 +4,7 @@ import * as _ from "lodash";
 import { BigNumber } from "bignumber.js";
 import * as Units from "../../../../test_utils/units";
 import * as moment from "moment";
-import { DecodedLog } from "abi-decoder";
+import * as Web3 from "web3";
 
 // Scenario runners
 import { RegisterRepaymentScenario, RegisterTermStartScenario } from "../scenarios";
@@ -19,6 +19,9 @@ import { DummyTokenContract } from "../../../../../../types/generated/dummy_toke
 import { CollateralizedSimpleInterestTermsParameters } from "../../../../factories/terms_contract_parameters";
 import { DebtOrderFactory } from "../../../../factories/debt_order_factory";
 
+// Utils
+import { Web3Utils } from "../../../../../../utils/web3_utils";
+
 const DEFAULT_GAS_AMOUNT = 4712388;
 
 export abstract class CollateralizedSimpleInterestTermsContractRunner {
@@ -27,7 +30,11 @@ export abstract class CollateralizedSimpleInterestTermsContractRunner {
     protected debtOrder: SignedDebtOrder;
     protected agreementId: string;
 
-    constructor() {
+    protected web3Utils: Web3Utils;
+
+    constructor(web3: Web3) {
+        this.web3Utils = new Web3Utils(web3);
+
         this.testScenario = this.testScenario.bind(this);
     }
 
@@ -40,7 +47,10 @@ export abstract class CollateralizedSimpleInterestTermsContractRunner {
         scenario: RegisterRepaymentScenario | RegisterTermStartScenario,
     ): void;
 
-    protected async getLogs(txHash: string, event: string): Promise<DecodedLog | undefined> {
+    protected async getLogs(
+        txHash: string,
+        event: string,
+    ): Promise<ABIDecoder.DecodedLog | undefined> {
         const receipt = await web3.eth.getTransactionReceipt(txHash);
 
         return _.find(ABIDecoder.decodeLogs(receipt.logs), { name: event });
@@ -72,24 +82,39 @@ export abstract class CollateralizedSimpleInterestTermsContractRunner {
             repaymentRouter,
             debtTokenContract,
             dummyREPToken,
+            dummyTokenRegistryContract,
         } = this.contracts;
 
         const { DEBTOR_1, CREDITOR_1, UNDERWRITER, RELAYER } = this.accounts;
 
+        const collateralTokenIndex = await dummyTokenRegistryContract.getTokenIndexBySymbol.callAsync(
+            "ZRX",
+        );
+        const principalTokenIndex = await dummyTokenRegistryContract.getTokenIndexBySymbol.callAsync(
+            "REP",
+        );
+        const nonExistentTokenIndex = new BigNumber(99);
+
         const termsContractParameters = CollateralizedSimpleInterestTermsParameters.pack(
             {
                 collateralAmount: scenario.collateralAmount,
-                collateralTokenIndex: scenario.collateralTokenIndexInRegistry,
+                collateralTokenIndex: scenario.collateralTokenInRegistry
+                    ? collateralTokenIndex
+                    : nonExistentTokenIndex,
                 gracePeriodInDays: scenario.gracePeriodInDays,
             },
             {
-                principalTokenIndex: scenario.principalTokenIndex,
+                principalTokenIndex: scenario.principalTokenInRegistry
+                    ? principalTokenIndex
+                    : nonExistentTokenIndex,
                 principalAmount: scenario.principalAmount,
                 interestRateFixedPoint: scenario.interestRateFixedPoint,
                 amortizationUnitType: scenario.amortizationUnitType,
                 termLengthUnits: scenario.termLengthUnits,
             },
         );
+
+        const latestBlockTime = await this.web3Utils.getCurrentBlockTime();
 
         const defaultOrderParams = {
             creditor: CREDITOR_1,
@@ -100,8 +125,9 @@ export abstract class CollateralizedSimpleInterestTermsContractRunner {
             debtor: DEBTOR_1,
             debtorFee: scenario.debtorFee,
             expirationTimestampInSec: new BigNumber(
-                moment()
-                    .add(1, "days")
+                moment
+                    .unix(latestBlockTime)
+                    .add(30, "days")
                     .unix(),
             ),
             issuanceVersion: repaymentRouter.address,

--- a/test/ts/integration/examples/collateralized_simple_interest_terms_contract/runners/index.ts
+++ b/test/ts/integration/examples/collateralized_simple_interest_terms_contract/runners/index.ts
@@ -26,6 +26,7 @@ export interface TestContracts {
     tokenTransferProxy: TokenTransferProxyContract;
     kernel: DebtKernelContract;
     dummyREPToken: DummyTokenContract;
+    dummyZRXToken: DummyTokenContract;
     collateralizedSimpleInterestTermsContract: CollateralizedSimpleInterestTermsContractContract;
     repaymentRouter: RepaymentRouterContract;
     dummyTokenRegistryContract: TokenRegistryContract;

--- a/test/ts/integration/examples/collateralized_simple_interest_terms_contract/runners/register_term_start.ts
+++ b/test/ts/integration/examples/collateralized_simple_interest_terms_contract/runners/register_term_start.ts
@@ -55,7 +55,7 @@ export class RegisterTermStartRunner extends CollateralizedSimpleInterestTermsCo
                 }
 
                 if (scenario.invokedByDebtKernel && !scenario.reverts) {
-                    const latestBlockTime = await this.web3Utils.getCurrentBlockTime();
+                    const latestBlockTime = await this.web3Utils.getLatestBlockTime();
 
                     // Fill the debt order, thereby invoking registerTermsStart from the debt kernel.
                     txHash = await this.fillDebtOrder();

--- a/test/ts/integration/examples/collateralized_simple_interest_terms_contract/runners/register_term_start.ts
+++ b/test/ts/integration/examples/collateralized_simple_interest_terms_contract/runners/register_term_start.ts
@@ -25,7 +25,7 @@ export class RegisterTermStartRunner extends CollateralizedSimpleInterestTermsCo
                 await this.setupDebtOrder(scenario);
 
                 // Reset the collateralizer contract's balance for each example.
-                await this.contracts.dummyREPToken.setBalance.sendTransactionAsync(
+                await this.contracts.dummyZRXToken.setBalance.sendTransactionAsync(
                     this.contracts.collateralizerContract.address,
                     new BigNumber(0),
                     {
@@ -33,7 +33,7 @@ export class RegisterTermStartRunner extends CollateralizedSimpleInterestTermsCo
                     },
                 );
 
-                await this.contracts.dummyREPToken.setBalance.sendTransactionAsync(
+                await this.contracts.dummyZRXToken.setBalance.sendTransactionAsync(
                     this.accounts.DEBTOR_1,
                     scenario.collateralTokenBalance,
                     {
@@ -41,7 +41,7 @@ export class RegisterTermStartRunner extends CollateralizedSimpleInterestTermsCo
                     },
                 );
 
-                await this.contracts.dummyREPToken.approve.sendTransactionAsync(
+                await this.contracts.dummyZRXToken.approve.sendTransactionAsync(
                     this.contracts.tokenTransferProxy.address,
                     scenario.collateralTokenAllowance,
                     { from: this.accounts.DEBTOR_1 },
@@ -55,6 +55,8 @@ export class RegisterTermStartRunner extends CollateralizedSimpleInterestTermsCo
                 }
 
                 if (scenario.invokedByDebtKernel && !scenario.reverts) {
+                    const latestBlockTime = await this.web3Utils.getCurrentBlockTime();
+
                     // Fill the debt order, thereby invoking registerTermsStart from the debt kernel.
                     txHash = await this.fillDebtOrder();
                 }
@@ -102,7 +104,7 @@ export class RegisterTermStartRunner extends CollateralizedSimpleInterestTermsCo
                     const expectedLog = CollateralLocked(
                         collateralizerContract.address,
                         this.agreementId,
-                        this.contracts.dummyREPToken.address,
+                        this.contracts.dummyZRXToken.address,
                         scenario.collateralAmount,
                     );
 
@@ -112,27 +114,17 @@ export class RegisterTermStartRunner extends CollateralizedSimpleInterestTermsCo
                 });
 
                 it("should decrement the balance for the debtor by the collateral amount", async () => {
-                    const balance = await this.contracts.dummyREPToken.balanceOf.callAsync(
+                    const balance = await this.contracts.dummyZRXToken.balanceOf.callAsync(
                         this.accounts.DEBTOR_1,
                     );
 
-                    if (
-                        scenario.collateralTokenIndexInRegistry.equals(scenario.principalTokenIndex)
-                    ) {
-                        const amountFromLoan = scenario.principalAmount.sub(scenario.debtorFee);
-
-                        expect(balance.toString()).to.equal(amountFromLoan.toString());
-                    } else {
-                        expect(balance.toString()).to.equal(
-                            scenario.collateralTokenBalance
-                                .sub(scenario.collateralAmount)
-                                .toString(),
-                        );
-                    }
+                    expect(balance.toString()).to.equal(
+                        scenario.collateralTokenBalance.sub(scenario.collateralAmount).toString(),
+                    );
                 });
 
                 it("should increment the collateralizer balance by the collateral amount", async () => {
-                    const balance = await this.contracts.dummyREPToken.balanceOf.callAsync(
+                    const balance = await this.contracts.dummyZRXToken.balanceOf.callAsync(
                         this.contracts.collateralizerContract.address,
                     );
 

--- a/test/ts/integration/examples/collateralized_simple_interest_terms_contract/scenarios/index.ts
+++ b/test/ts/integration/examples/collateralized_simple_interest_terms_contract/scenarios/index.ts
@@ -10,8 +10,6 @@ import { SignedDebtOrder } from "../../../../../../types/kernel/debt_order";
 
 export const DEFAULT_REGISTER_TERM_START_ARGS = {
     // Simple terms parameters.
-    // Our migrations set REP up to be at index 0 of the registry.
-    principalTokenIndex: new BigNumber(0),
     principalAmount: Units.ether(1),
     interestRateFixedPoint: Units.interestRateFixedPoint(2.5),
     amortizationUnitType: new BigNumber(1),
@@ -20,13 +18,14 @@ export const DEFAULT_REGISTER_TERM_START_ARGS = {
     collateralAmount: Units.ether(0.005),
     collateralToken: "REP",
     gracePeriodInDays: new BigNumber(20),
-    collateralTokenIndexInRegistry: new BigNumber(0),
     // Misc parameters.
     collateralTokenAllowance: Units.ether(0.005),
     collateralTokenBalance: Units.ether(0.005),
     debtorFee: Units.ether(0.001),
     invokedByDebtKernel: true,
     permissionToCollateralize: true,
+    principalTokenInRegistry: true,
+    collateralTokenInRegistry: true,
     succeeds: true,
     reverts: false,
     termsContractParameters: (terms: SimpleInterestContractTerms) =>
@@ -34,7 +33,6 @@ export const DEFAULT_REGISTER_TERM_START_ARGS = {
 };
 
 export const DEFAULT_REGISTER_REPAYMENT_ARGS = {
-    principalTokenIndex: new BigNumber(0),
     principalAmount: Units.ether(1),
     interestRateFixedPoint: Units.interestRateFixedPoint(2.5),
     amortizationUnitType: new BigNumber(1),
@@ -45,7 +43,6 @@ export const DEFAULT_REGISTER_REPAYMENT_ARGS = {
     collateralAmount: Units.ether(0.005),
     collateralToken: "REP",
     gracePeriodInDays: new BigNumber(20),
-    collateralTokenIndexInRegistry: new BigNumber(0),
     // Misc parameters.
     collateralTokenAllowance: Units.ether(0.005),
     collateralTokenBalance: Units.ether(0.005),
@@ -53,6 +50,8 @@ export const DEFAULT_REGISTER_REPAYMENT_ARGS = {
         principalToken,
     debtOrder: (debtOrder: SignedDebtOrder) => debtOrder,
     repayFromRouter: true,
+    principalTokenInRegistry: true,
+    collateralTokenInRegistry: true,
     succeeds: true,
     reverts: false,
 };
@@ -60,8 +59,6 @@ export const DEFAULT_REGISTER_REPAYMENT_ARGS = {
 export interface RegisterRepaymentScenario {
     // The test's description
     description: string;
-    // The index of the principal token in the registry.
-    principalTokenIndex: BigNumber;
     // The debt order's principal amount.
     principalAmount: BigNumber;
     // The debt order's interest rate (in fixed point).
@@ -84,9 +81,12 @@ export interface RegisterRepaymentScenario {
     collateralAmount: BigNumber;
     collateralToken: string;
     gracePeriodInDays: BigNumber;
-    collateralTokenIndexInRegistry: BigNumber;
     collateralTokenAllowance: BigNumber;
     collateralTokenBalance: BigNumber;
+    // True if the index associated with the principal token is in the token registry
+    principalTokenInRegistry: boolean;
+    // True if the index associated with the collateral token is in the token registry
+    collateralTokenInRegistry: boolean;
     // True if repayment gets logged.
     succeeds: boolean;
     // True if the transaction is reverted.
@@ -98,8 +98,6 @@ export interface RegisterRepaymentScenario {
 export interface RegisterTermStartScenario {
     // The test's description
     description: string;
-    // The index of the principal token in the registry.
-    principalTokenIndex: BigNumber;
     // The debt order's principal amount.
     principalAmount: BigNumber;
     // The debt order's interest rate (in fixed point).
@@ -117,9 +115,12 @@ export interface RegisterTermStartScenario {
     collateralAmount: BigNumber;
     collateralToken: string;
     gracePeriodInDays: BigNumber;
-    collateralTokenIndexInRegistry: BigNumber;
     collateralTokenAllowance: BigNumber;
     collateralTokenBalance: BigNumber;
+    // True if the index associated with the principal token is in the token registry
+    principalTokenInRegistry: boolean;
+    // True if the index associated with the collateral token is in the token registry
+    collateralTokenInRegistry: boolean;
     // True if the scenario does not revert and the terms contract is started.
     succeeds: boolean;
     // True if the transaction reverts during the scenario.

--- a/test/ts/integration/examples/collateralized_simple_interest_terms_contract/scenarios/unsuccessful_register_term_start.ts
+++ b/test/ts/integration/examples/collateralized_simple_interest_terms_contract/scenarios/unsuccessful_register_term_start.ts
@@ -32,15 +32,16 @@ export const UNSUCCESSFUL_REGISTER_TERM_START_SCENARIOS: RegisterTermStartScenar
         principalAmount: new BigNumber(0),
     },
     {
-        description: "when there is no token at the given token index in the terms contract parameters",
+        description:
+            "when there is no token at the given token index in the terms contract parameters",
         ...defaultArgs,
-        principalTokenIndex: new BigNumber(99),
+        principalTokenInRegistry: false,
         reverts: true,
     },
     {
         description: "when there is no token at the given token index in the collateral parameters",
         ...defaultArgs,
-        collateralTokenIndexInRegistry: new BigNumber(99),
+        collateralTokenInRegistry: false,
         reverts: true,
     },
     {
@@ -50,7 +51,8 @@ export const UNSUCCESSFUL_REGISTER_TERM_START_SCENARIOS: RegisterTermStartScenar
         reverts: true,
     },
     {
-        description: "when the token proxy allowance granted by the debtor is less than the collateral amount",
+        description:
+            "when the token proxy allowance granted by the debtor is less than the collateral amount",
         ...defaultArgs,
         collateralTokenAllowance: new BigNumber(0),
         reverts: true,

--- a/test/ts/integration/examples/simple_interest_terms_contract/scenarios/index.ts
+++ b/test/ts/integration/examples/simple_interest_terms_contract/scenarios/index.ts
@@ -9,12 +9,12 @@ import { DummyTokenContract } from "../../../../../../types/generated/dummy_toke
 import { SignedDebtOrder } from "../../../../../../types/kernel/debt_order";
 
 export const DEFAULT_REGISTER_TERM_START_ARGS = {
-    principalTokenIndex: new BigNumber(0),
     principalAmount: Units.ether(1),
     interestRateFixedPoint: Units.interestRateFixedPoint(2.5),
     amortizationUnitType: new BigNumber(1),
     termLengthUnits: new BigNumber(4),
     invokedByDebtKernel: true,
+    principalTokenInRegistry: true,
     succeeds: true,
     reverts: false,
     termsContractParameters: (terms: SimpleInterestContractTerms) =>
@@ -22,7 +22,6 @@ export const DEFAULT_REGISTER_TERM_START_ARGS = {
 };
 
 export const DEFAULT_REGISTER_REPAYMENT_ARGS = {
-    principalTokenIndex: new BigNumber(0),
     principalAmount: Units.ether(1),
     interestRateFixedPoint: Units.interestRateFixedPoint(2.5),
     amortizationUnitType: new BigNumber(1),
@@ -31,6 +30,7 @@ export const DEFAULT_REGISTER_REPAYMENT_ARGS = {
     repaymentToken: (principalToken: DummyTokenContract, otherToken: DummyTokenContract) =>
         principalToken,
     debtOrder: (debtOrder: SignedDebtOrder) => debtOrder,
+    principalTokenInRegistry: true,
     repayFromRouter: true,
     succeeds: true,
     reverts: false,
@@ -39,8 +39,6 @@ export const DEFAULT_REGISTER_REPAYMENT_ARGS = {
 export interface RegisterRepaymentScenario {
     // The test's description
     description: string;
-    // The index of the principal token in the registry.
-    principalTokenIndex: BigNumber;
     // The debt order's principal amount.
     principalAmount: BigNumber;
     // The debt order's interest rate (in fixed point).
@@ -58,6 +56,8 @@ export interface RegisterRepaymentScenario {
     ) => DummyTokenContract;
     // The debt order to use in this scenario.
     debtOrder: (debtOrder: SignedDebtOrder) => SignedDebtOrder;
+    // True if registry tracks token with principal token's index.
+    principalTokenInRegistry: boolean;
     // True if repayment gets logged.
     succeeds: boolean;
     // True if the transaction is reverted.
@@ -69,8 +69,6 @@ export interface RegisterRepaymentScenario {
 export interface RegisterTermStartScenario {
     // The test's description
     description: string;
-    // The index of the principal token in the registry.
-    principalTokenIndex: BigNumber;
     // The debt order's principal amount.
     principalAmount: BigNumber;
     // The debt order's interest rate (in fixed point).
@@ -81,6 +79,8 @@ export interface RegisterTermStartScenario {
     termLengthUnits: BigNumber;
     // Given some contract terms, returns a packed version to be used in the scenario.
     termsContractParameters: (terms: SimpleInterestContractTerms) => string;
+    // True if registry tracks token with principal token's index.
+    principalTokenInRegistry: boolean;
     // True if the scenario does not revert and the terms contract is started.
     succeeds: boolean;
     // True if the transaction reverts during the scenario.

--- a/test/ts/integration/examples/simple_interest_terms_contract/scenarios/unsuccessful_register_term_start.ts
+++ b/test/ts/integration/examples/simple_interest_terms_contract/scenarios/unsuccessful_register_term_start.ts
@@ -26,9 +26,10 @@ export const UNSUCCESSFUL_REGISTER_TERM_START_SCENARIOS: RegisterTermStartScenar
         principalAmount: new BigNumber(0),
     },
     {
-        description: "when there is no token at the given token index in the terms contract parameters",
+        description:
+            "when there is no token at the given token index in the terms contract parameters",
         ...defaultArgs,
         reverts: true,
-        principalTokenIndex: new BigNumber(99),
+        principalTokenInRegistry: false,
     },
 ];

--- a/test/ts/integration/examples/simple_interest_terms_contract/simple_interest_terms_contract.ts
+++ b/test/ts/integration/examples/simple_interest_terms_contract/simple_interest_terms_contract.ts
@@ -26,7 +26,11 @@ import { UNSUCCESSFUL_REGISTER_TERM_START_SCENARIOS } from "./scenarios/unsucces
 import { UNPACK_PARAMETERS_FROM_BYTES_SCENARIOS } from "./scenarios/unpack_parameters_from_bytes";
 
 // Scenario Runners
-import { RegisterRepaymentRunner, RegisterTermStartRunner, UnpackParametersFromBytesRunner } from "./runners";
+import {
+    RegisterRepaymentRunner,
+    RegisterTermStartRunner,
+    UnpackParametersFromBytesRunner,
+} from "./runners";
 
 contract("Simple Interest Terms Contract (Integration Tests)", async (ACCOUNTS) => {
     let kernel: DebtKernelContract;
@@ -47,8 +51,8 @@ contract("Simple Interest Terms Contract (Integration Tests)", async (ACCOUNTS) 
 
     const TX_DEFAULTS = { from: CONTRACT_OWNER, gas: 4712388 };
 
-    const registerRepaymentRunner = new RegisterRepaymentRunner();
-    const registerTermStartRunner = new RegisterTermStartRunner();
+    const registerRepaymentRunner = new RegisterRepaymentRunner(web3);
+    const registerTermStartRunner = new RegisterTermStartRunner(web3);
     const unpackParametersFromBytes = new UnpackParametersFromBytesRunner();
 
     before(async () => {
@@ -103,7 +107,9 @@ contract("Simple Interest Terms Contract (Integration Tests)", async (ACCOUNTS) 
         });
 
         describe("Unsuccessful register term start", () => {
-            UNSUCCESSFUL_REGISTER_TERM_START_SCENARIOS.forEach(registerTermStartRunner.testScenario);
+            UNSUCCESSFUL_REGISTER_TERM_START_SCENARIOS.forEach(
+                registerTermStartRunner.testScenario,
+            );
         });
     });
 

--- a/test/ts/integration/repayment_router.ts
+++ b/test/ts/integration/repayment_router.ts
@@ -74,6 +74,9 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
         const dummyREPTokenAddress = await dummyTokenRegistryContract.getTokenAddressBySymbol.callAsync(
             "REP",
         );
+        const dummyREPTokenIndex = await dummyTokenRegistryContract.getTokenIndexBySymbol.callAsync(
+            "REP",
+        );
 
         principalToken = await DummyTokenContract.at(dummyREPTokenAddress, web3, TX_DEFAULTS);
 
@@ -99,14 +102,14 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
         termsContract = await SimpleInterestTermsContractContract.deployed(web3, TX_DEFAULTS);
 
         const termsContractParameters = SimpleInterestParameters.pack({
-            principalTokenIndex: new BigNumber(0), // Our migrations set REP up to be at index 0 of the registry
+            principalTokenIndex: dummyREPTokenIndex,
             principalAmount: Units.ether(1),
             interestRateFixedPoint: Units.interestRateFixedPoint(2.5),
             amortizationUnitType: new BigNumber(1), // (weekly)
             termLengthUnits: new BigNumber(4),
         });
 
-        const latestBlockTime = await web3Utils.getCurrentBlockTime();
+        const latestBlockTime = await web3Utils.getLatestBlockTime();
 
         const defaultOrderParams = {
             creditorFee: Units.ether(0.002),
@@ -118,7 +121,7 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
             expirationTimestampInSec: new BigNumber(
                 moment
                     .unix(latestBlockTime)
-                    .add(1, "days")
+                    .add(30, "days")
                     .unix(),
             ),
             issuanceVersion: router.address,

--- a/test/ts/integration/repayment_router.ts
+++ b/test/ts/integration/repayment_router.ts
@@ -26,6 +26,7 @@ import { SignedDebtOrder } from "../../../types/kernel/debt_order";
 import { BigNumberSetup } from "../test_utils/bignumber_setup";
 import ChaiSetup from "../test_utils/chai_setup";
 import { REVERT_ERROR } from "../test_utils/constants";
+import { Web3Utils } from "../../../utils/web3_utils";
 
 import { LogError, LogRepayment } from "../logs/repayment_router";
 import {
@@ -39,6 +40,9 @@ const expect = chai.expect;
 
 // Configure BigNumber exponentiation
 BigNumberSetup.configure();
+
+// Set up web3 utils
+const web3Utils = new Web3Utils(web3);
 
 contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
     let router: RepaymentRouterContract;
@@ -102,6 +106,8 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
             termLengthUnits: new BigNumber(4),
         });
 
+        const latestBlockTime = await web3Utils.getCurrentBlockTime();
+
         const defaultOrderParams = {
             creditorFee: Units.ether(0.002),
             debtKernelContract: kernel.address,
@@ -110,7 +116,8 @@ contract("Repayment Router (Integration Tests)", async (ACCOUNTS) => {
             debtor: DEBTOR,
             debtorFee: Units.ether(0.001),
             expirationTimestampInSec: new BigNumber(
-                moment()
+                moment
+                    .unix(latestBlockTime)
                     .add(1, "days")
                     .unix(),
             ),

--- a/test/ts/integration/token_registry.ts
+++ b/test/ts/integration/token_registry.ts
@@ -173,9 +173,9 @@ contract("Token Registry (Integration Tests)", async (ACCOUNTS) => {
 
         // Store the token's original attributes, so that we can restore them after tests.
         let originalAddress: string;
+        let originalIndex: BigNumber;
         let originalName: string;
         let originalNumDecimals: BigNumber;
-        let originalSymbol: string;
 
         describe("when called by the multi-sig contract owner", () => {
             before("store the original token attributes and then set the new ones", async () => {
@@ -183,8 +183,8 @@ contract("Token Registry (Integration Tests)", async (ACCOUNTS) => {
 
                 [
                     originalAddress,
+                    originalIndex,
                     originalName,
-                    originalSymbol,
                     originalNumDecimals,
                 ] = await registry.getTokenAttributesBySymbol.callAsync(symbol);
 

--- a/test/ts/test_utils/multisig.ts
+++ b/test/ts/test_utils/multisig.ts
@@ -139,6 +139,14 @@ export async function multiSigExecuteAfterTimelock(
     await web3Utils.increaseTime(timelock);
 
     await multiSig.executeTransaction.sendTransactionAsync(transactionId);
+
+    const transaction = await multiSig.transactions.callAsync(transactionId);
+
+    const [destination, value, data, executedSuccessfully] = transaction;
+
+    if (!executedSuccessfully) {
+        throw new Error(`Multisig transaction with ID #${transactionId} failed to execute.`);
+    }
 }
 
 /**
@@ -177,4 +185,12 @@ export async function multiSigExecutePauseImmediately(
     );
 
     await multiSig.executePauseTransactionImmediately.sendTransactionAsync(transactionId);
+
+    const transaction = await multiSig.transactions.callAsync(transactionId);
+
+    const [destination, value, data, executedSuccessfully] = transaction;
+
+    if (!executedSuccessfully) {
+        throw new Error(`Multisig transaction with ID #${transactionId} failed to execute.`);
+    }
 }

--- a/test/ts/unit/collateralizer/collateralizer.ts
+++ b/test/ts/unit/collateralizer/collateralizer.ts
@@ -46,8 +46,8 @@ contract("CollateralizedContract (Unit Tests)", async (ACCOUNTS) => {
     let mockTermsContract: MockCollateralizedTermsContractContract;
 
     const collateralizeRunner = new CollateralizeRunner();
-    const returnCollateralRunner = new ReturnCollateralRunner();
-    const seizeCollateralRunner = new SeizeCollateralRunner();
+    const returnCollateralRunner = new ReturnCollateralRunner(web3);
+    const seizeCollateralRunner = new SeizeCollateralRunner(web3);
 
     const CONTRACT_OWNER = ACCOUNTS[0];
     const COLLATERALIZER = ACCOUNTS[1];
@@ -70,7 +70,10 @@ contract("CollateralizedContract (Unit Tests)", async (ACCOUNTS) => {
         mockToken = await MockERC20TokenContract.deployed(web3, TX_DEFAULTS);
         mockTokenRegistry = await MockTokenRegistryContract.deployed(web3, TX_DEFAULTS);
         mockTokenTransferProxy = await MockTokenTransferProxyContract.deployed(web3, TX_DEFAULTS);
-        mockTermsContract = await MockCollateralizedTermsContractContract.deployed(web3, TX_DEFAULTS);
+        mockTermsContract = await MockCollateralizedTermsContractContract.deployed(
+            web3,
+            TX_DEFAULTS,
+        );
 
         /*
         In our test environment, we want to interact with the contract being
@@ -215,13 +218,13 @@ contract("CollateralizedContract (Unit Tests)", async (ACCOUNTS) => {
     });
 
     describe("#collateralize", () => {
-       describe("Successful collateralization", () => {
-           SUCCESSFUL_COLLATERALIZATION_SCENARIOS.forEach(collateralizeRunner.testScenario);
-       });
+        describe("Successful collateralization", () => {
+            SUCCESSFUL_COLLATERALIZATION_SCENARIOS.forEach(collateralizeRunner.testScenario);
+        });
 
-       describe("Unsuccessful collateralization", () => {
+        describe("Unsuccessful collateralization", () => {
             UNSUCCESSFUL_COLLATERALIZATION_SCENARIOS.forEach(collateralizeRunner.testScenario);
-       });
+        });
     });
 
     describe("#returnCollateral", () => {

--- a/test/ts/unit/collateralizer/runners/index.ts
+++ b/test/ts/unit/collateralizer/runners/index.ts
@@ -24,7 +24,7 @@ export interface TestContracts {
 }
 
 export interface ExpectedRepaymentValueDate {
-    timestamp: number;
+    timestamp: (latestBlockTime: number) => number;
     expectedRepaymentValue: BigNumber;
 }
 
@@ -79,7 +79,7 @@ export interface ReturnCollateralScenario {
     // Current value repaid to date
     valueRepaidToDate: BigNumber;
     // The timestamp of the debt's term end
-    termEndTimestamp: number;
+    termEndTimestamp: (latestBlockTime: number) => number;
     // Schedule for expected repayment value
     expectedRepaymentValueSchedule: ExpectedRepaymentValueDate[];
     // Specifies whether the terms contract associated with

--- a/test/ts/unit/collateralizer/runners/return_collateral.ts
+++ b/test/ts/unit/collateralizer/runners/return_collateral.ts
@@ -3,6 +3,7 @@ import { expect } from "chai";
 import * as ABIDecoder from "abi-decoder";
 import { compact } from "lodash";
 import { BigNumber } from "bignumber.js";
+import * as Web3 from "web3";
 
 // Wrappers
 import { CollateralizerContract } from "types/generated/collateralizer";
@@ -17,6 +18,7 @@ import { ReturnCollateralScenario, TestAccounts, TestContracts } from "./";
 
 // Test Utils
 import { NULL_ADDRESS, REVERT_ERROR } from "../../../test_utils/constants";
+import { Web3Utils } from "../../../../../utils/web3_utils";
 
 // Factories
 import { CollateralizedSimpleInterestTermsParameters } from "../../../factories/terms_contract_parameters";
@@ -27,8 +29,11 @@ import { CollateralReturned } from "../../../logs/collateralized_contract";
 export class ReturnCollateralRunner {
     private contracts: TestContracts;
     private accounts: TestAccounts;
+    private web3Utils: Web3Utils;
 
-    constructor() {
+    constructor(web3: Web3) {
+        this.web3Utils = new Web3Utils(web3);
+
         this.testScenario = this.testScenario.bind(this);
     }
 
@@ -71,6 +76,8 @@ export class ReturnCollateralRunner {
                 await mockDebtRegistry.reset.sendTransactionAsync();
                 await mockCollateralToken.reset.sendTransactionAsync();
                 await mockTokenRegistry.reset.sendTransactionAsync();
+
+                const latestBlockTime = await this.web3Utils.getCurrentBlockTime();
 
                 // We mock the collateralized agreement by taking the following steps:
                 // 1.  Mocking the collateral token as being placed at index 0
@@ -136,7 +143,7 @@ export class ReturnCollateralRunner {
                 for (const repaymentDate of scenario.expectedRepaymentValueSchedule) {
                     await mockTermsContract.mockExpectedRepaymentValue.sendTransactionAsync(
                         scenario.agreementId,
-                        new BigNumber(repaymentDate.timestamp),
+                        new BigNumber(repaymentDate.timestamp(latestBlockTime)),
                         repaymentDate.expectedRepaymentValue,
                     );
                 }
@@ -150,7 +157,7 @@ export class ReturnCollateralRunner {
                 // 7.  Mocking the debt term's ending timestamp
                 await mockTermsContract.mockTermEndTimestamp.sendTransactionAsync(
                     scenario.agreementId,
-                    new BigNumber(scenario.termEndTimestamp),
+                    new BigNumber(scenario.termEndTimestamp(latestBlockTime)),
                 );
 
                 if (typeof scenario.before !== "undefined") {
@@ -176,9 +183,7 @@ export class ReturnCollateralRunner {
 
                 it("should erase record of current collateralization", async () => {
                     await expect(
-                        collateralizer.agreementToCollateralizer.callAsync(
-                            scenario.agreementId,
-                        ),
+                        collateralizer.agreementToCollateralizer.callAsync(scenario.agreementId),
                     ).to.eventually.equal(NULL_ADDRESS);
                 });
 
@@ -208,10 +213,9 @@ export class ReturnCollateralRunner {
             } else {
                 it("should throw", async () => {
                     await expect(
-                        collateralizer.returnCollateral.sendTransactionAsync(
-                            scenario.agreementId,
-                            { from: scenario.from(COLLATERALIZER, NON_COLLATERALIZER) },
-                        ),
+                        collateralizer.returnCollateral.sendTransactionAsync(scenario.agreementId, {
+                            from: scenario.from(COLLATERALIZER, NON_COLLATERALIZER),
+                        }),
                     ).to.eventually.be.rejectedWith(REVERT_ERROR);
                 });
             }

--- a/test/ts/unit/collateralizer/runners/return_collateral.ts
+++ b/test/ts/unit/collateralizer/runners/return_collateral.ts
@@ -77,7 +77,7 @@ export class ReturnCollateralRunner {
                 await mockCollateralToken.reset.sendTransactionAsync();
                 await mockTokenRegistry.reset.sendTransactionAsync();
 
-                const latestBlockTime = await this.web3Utils.getCurrentBlockTime();
+                const latestBlockTime = await this.web3Utils.getLatestBlockTime();
 
                 // We mock the collateralized agreement by taking the following steps:
                 // 1.  Mocking the collateral token as being placed at index 0

--- a/test/ts/unit/collateralizer/runners/seize_collateral.ts
+++ b/test/ts/unit/collateralizer/runners/seize_collateral.ts
@@ -78,7 +78,7 @@ export class SeizeCollateralRunner {
                 await mockCollateralToken.reset.sendTransactionAsync();
                 await mockTokenRegistry.reset.sendTransactionAsync();
 
-                const latestBlockTime = await this.web3Utils.getCurrentBlockTime();
+                const latestBlockTime = await this.web3Utils.getLatestBlockTime();
 
                 // We mock the collateralized agreement by taking the following steps:
                 // 1.  Mocking the collateral token as being placed at index 0

--- a/test/ts/unit/collateralizer/scenarios/successful_return.ts
+++ b/test/ts/unit/collateralizer/scenarios/successful_return.ts
@@ -13,9 +13,11 @@ const defaultArgs = {
     debtAgreementCollateralized: true,
     termsContract: (collateralizedContract: string, attacker: string) => collateralizedContract,
     // Some time past the last date in the repayment schedule.
-    termEndTimestamp: moment()
-        .subtract(5, "days")
-        .unix(),
+    termEndTimestamp: (latestBlockTime: number) =>
+        moment
+            .unix(latestBlockTime)
+            .subtract(5, "days")
+            .unix(),
 };
 
 export const SUCCESSFUL_RETURN_SCENARIOS: ReturnCollateralScenario[] = [
@@ -27,15 +29,19 @@ export const SUCCESSFUL_RETURN_SCENARIOS: ReturnCollateralScenario[] = [
         valueRepaidToDate: Units.ether(1),
         expectedRepaymentValueSchedule: [
             {
-                timestamp: moment()
-                    .subtract(14, "days")
-                    .unix(),
+                timestamp: (latestBlockTime: number) =>
+                    moment
+                        .unix(latestBlockTime)
+                        .subtract(14, "days")
+                        .unix(),
                 expectedRepaymentValue: Units.ether(0.5),
             },
             {
-                timestamp: moment()
-                    .subtract(7, "days")
-                    .unix(),
+                timestamp: (latestBlockTime: number) =>
+                    moment
+                        .unix(latestBlockTime)
+                        .subtract(7, "days")
+                        .unix(),
                 expectedRepaymentValue: Units.ether(1),
             },
         ],
@@ -51,9 +57,11 @@ export const SUCCESSFUL_RETURN_SCENARIOS: ReturnCollateralScenario[] = [
         valueRepaidToDate: Units.ether(3),
         expectedRepaymentValueSchedule: [
             {
-                timestamp: moment()
-                    .subtract(7, "days")
-                    .unix(),
+                timestamp: (latestBlockTime: number) =>
+                    moment
+                        .unix(latestBlockTime)
+                        .subtract(7, "days")
+                        .unix(),
                 expectedRepaymentValue: Units.ether(2),
             },
         ],
@@ -61,19 +69,28 @@ export const SUCCESSFUL_RETURN_SCENARIOS: ReturnCollateralScenario[] = [
         agreementId: web3.sha3("Arbitrary 32 byte string for successful return scenario #2"),
     },
     {
-        description: "Debt's term has not yet lapsed, and debt has been fully repaid, called by non-collateralizer",
+        description:
+            "Debt's term has not yet lapsed, and debt has been fully repaid, called by non-collateralizer",
         ...defaultArgs,
         collateralAmount: Units.ether(0.5),
         gracePeriodInDays: new BigNumber(3),
         valueRepaidToDate: Units.ether(3),
         expectedRepaymentValueSchedule: [
             {
-                timestamp: moment().add(1, "days").unix(),
+                timestamp: (latestBlockTime: number) =>
+                    moment
+                        .unix(latestBlockTime)
+                        .add(1, "days")
+                        .unix(),
                 expectedRepaymentValue: Units.ether(2),
             },
         ],
         from: (collateralizer: string, other: string) => other,
-        termEndTimestamp: moment().add(1, "days").unix(),
+        termEndTimestamp: (latestBlockTime: number) =>
+            moment
+                .unix(latestBlockTime)
+                .add(1, "days")
+                .unix(),
         agreementId: web3.sha3("Arbitrary 32 byte string for unsuccessful return scenario #3"),
     },
 ];

--- a/test/ts/unit/collateralizer/scenarios/successful_seizure.ts
+++ b/test/ts/unit/collateralizer/scenarios/successful_seizure.ts
@@ -13,9 +13,11 @@ const defaultArgs = {
     valueRepaidToDate: Units.ether(0),
     expectedRepaymentValueSchedule: [
         {
-            timestamp: moment()
-                .subtract(8, "days")
-                .unix(),
+            timestamp: (latestBlockTime: number) =>
+                moment
+                    .unix(latestBlockTime)
+                    .subtract(8, "days")
+                    .unix(),
             expectedRepaymentValue: Units.ether(0.5),
         },
     ],
@@ -36,9 +38,11 @@ export const SUCCESSFUL_SEIZURE_SCENARIOS: SeizeCollateralScenario[] = [
         gracePeriodInDays: new BigNumber(0),
         expectedRepaymentValueSchedule: [
             {
-                timestamp: moment()
-                    .subtract(1, "hours")
-                    .unix(),
+                timestamp: (latestBlockTime: number) =>
+                    moment
+                        .unix(latestBlockTime)
+                        .subtract(1, "hours")
+                        .unix(),
                 expectedRepaymentValue: Units.ether(0.5),
             },
         ],
@@ -51,9 +55,11 @@ export const SUCCESSFUL_SEIZURE_SCENARIOS: SeizeCollateralScenario[] = [
         gracePeriodInDays: new BigNumber(0),
         expectedRepaymentValueSchedule: [
             {
-                timestamp: moment()
-                    .subtract(1, "hours")
-                    .unix(),
+                timestamp: (latestBlockTime: number) =>
+                    moment
+                        .unix(latestBlockTime)
+                        .subtract(1, "hours")
+                        .unix(),
                 expectedRepaymentValue: Units.ether(0.5),
             },
         ],
@@ -68,9 +74,11 @@ export const SUCCESSFUL_SEIZURE_SCENARIOS: SeizeCollateralScenario[] = [
         valueRepaidToDate: Units.ether(0.5).minus(1),
         expectedRepaymentValueSchedule: [
             {
-                timestamp: moment()
-                    .subtract(1, "hours")
-                    .unix(),
+                timestamp: (latestBlockTime: number) =>
+                    moment
+                        .unix(latestBlockTime)
+                        .subtract(1, "hours")
+                        .unix(),
                 expectedRepaymentValue: Units.ether(0.5),
             },
         ],
@@ -106,9 +114,11 @@ export const SUCCESSFUL_SEIZURE_SCENARIOS: SeizeCollateralScenario[] = [
         gracePeriodInDays: new BigNumber(90),
         expectedRepaymentValueSchedule: [
             {
-                timestamp: moment()
-                    .subtract(91, "days")
-                    .unix(),
+                timestamp: (latestBlockTime: number) =>
+                    moment
+                        .unix(latestBlockTime)
+                        .subtract(91, "days")
+                        .unix(),
                 expectedRepaymentValue: Units.ether(0.5),
             },
         ],
@@ -121,9 +131,11 @@ export const SUCCESSFUL_SEIZURE_SCENARIOS: SeizeCollateralScenario[] = [
         gracePeriodInDays: new BigNumber(90),
         expectedRepaymentValueSchedule: [
             {
-                timestamp: moment()
-                    .subtract(91, "days")
-                    .unix(),
+                timestamp: (latestBlockTime: number) =>
+                    moment
+                        .unix(latestBlockTime)
+                        .subtract(91, "days")
+                        .unix(),
                 expectedRepaymentValue: Units.ether(0.5),
             },
         ],
@@ -138,9 +150,11 @@ export const SUCCESSFUL_SEIZURE_SCENARIOS: SeizeCollateralScenario[] = [
         gracePeriodInDays: new BigNumber(90),
         expectedRepaymentValueSchedule: [
             {
-                timestamp: moment()
-                    .subtract(91, "days")
-                    .unix(),
+                timestamp: (latestBlockTime: number) =>
+                    moment
+                        .unix(latestBlockTime)
+                        .subtract(91, "days")
+                        .unix(),
                 expectedRepaymentValue: Units.ether(0.5),
             },
         ],

--- a/test/ts/unit/collateralizer/scenarios/unsuccessful_return.ts
+++ b/test/ts/unit/collateralizer/scenarios/unsuccessful_return.ts
@@ -18,21 +18,27 @@ const defaultArgs = {
     valueRepaidToDate: Units.ether(1),
     expectedRepaymentValueSchedule: [
         {
-            timestamp: moment()
-                .subtract(14, "days")
-                .unix(),
+            timestamp: (latestBlockTime: number) =>
+                moment
+                    .unix(latestBlockTime)
+                    .subtract(14, "days")
+                    .unix(),
             expectedRepaymentValue: Units.ether(0.5),
         },
         {
-            timestamp: moment()
-                .subtract(7, "days")
-                .unix(),
+            timestamp: (latestBlockTime: number) =>
+                moment
+                    .unix(latestBlockTime)
+                    .subtract(7, "days")
+                    .unix(),
             expectedRepaymentValue: Units.ether(1),
         },
     ],
-    termEndTimestamp: moment()
-        .subtract(1, "hours")
-        .unix(),
+    termEndTimestamp: (latestBlockTime: number) =>
+        moment
+            .unix(latestBlockTime)
+            .subtract(1, "hours")
+            .unix(),
     termsContract: (collateralizedContract: string, attacker: string) => collateralizedContract,
     from: (collateralizer: string, other: string) => collateralizer,
     debtAgreementExists: true,

--- a/test/ts/unit/collateralizer/scenarios/unsuccessful_seizure.ts
+++ b/test/ts/unit/collateralizer/scenarios/unsuccessful_seizure.ts
@@ -18,9 +18,11 @@ const defaultArgs = {
     valueRepaidToDate: Units.ether(0.5).minus(1),
     expectedRepaymentValueSchedule: [
         {
-            timestamp: moment()
-                .subtract(8, "days")
-                .unix(),
+            timestamp: (latestBlockTime: number) =>
+                moment
+                    .unix(latestBlockTime)
+                    .subtract(8, "days")
+                    .unix(),
             expectedRepaymentValue: Units.ether(0.5),
         },
     ],
@@ -75,9 +77,11 @@ export const UNSUCCESSFUL_SEIZURE_SCENARIOS: SeizeCollateralScenario[] = [
         ...defaultArgs,
         expectedRepaymentValueSchedule: [
             {
-                timestamp: moment()
-                    .subtract(6, "days")
-                    .unix(),
+                timestamp: (latestBlockTime: number) =>
+                    moment
+                        .unix(latestBlockTime)
+                        .subtract(6, "days")
+                        .unix(),
                 expectedRepaymentValue: Units.ether(0.5),
             },
         ],
@@ -97,9 +101,11 @@ export const UNSUCCESSFUL_SEIZURE_SCENARIOS: SeizeCollateralScenario[] = [
         gracePeriodInDays: new BigNumber(90),
         expectedRepaymentValueSchedule: [
             {
-                timestamp: moment()
-                    .subtract(89, "days")
-                    .unix(),
+                timestamp: (latestBlockTime: number) =>
+                    moment
+                        .unix(latestBlockTime)
+                        .subtract(89, "days")
+                        .unix(),
                 expectedRepaymentValue: Units.ether(0.5),
             },
         ],
@@ -130,11 +136,7 @@ export const UNSUCCESSFUL_SEIZURE_SCENARIOS: SeizeCollateralScenario[] = [
             // Mock the debt term's ending timestamp as having lapsed so that we can return collateral
             await termsContract.mockTermEndTimestamp.sendTransactionAsync(
                 agreementId,
-                new BigNumber(
-                    moment()
-                        .subtract(1, "hours")
-                        .unix(),
-                ),
+                new BigNumber(0),
             );
 
             await collateralizerContract.returnCollateral.sendTransactionAsync(agreementId);
@@ -146,9 +148,11 @@ export const UNSUCCESSFUL_SEIZURE_SCENARIOS: SeizeCollateralScenario[] = [
         ...defaultArgs,
         expectedRepaymentValueSchedule: [
             {
-                timestamp: moment()
-                    .subtract(6, "days")
-                    .unix(),
+                timestamp: (latestBlockTime: number) =>
+                    moment
+                        .unix(latestBlockTime)
+                        .subtract(6, "days")
+                        .unix(),
                 expectedRepaymentValue: new BigNumber(0),
             },
         ],

--- a/test/ts/unit/debt_kernel.ts
+++ b/test/ts/unit/debt_kernel.ts
@@ -129,7 +129,7 @@ contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
         mockDebtToken = await MockDebtTokenContract.deployed(web3, TX_DEFAULTS);
         mockPrincipalToken = await MockERC20TokenContract.deployed(web3, TX_DEFAULTS);
 
-        const latestBlockTime = await web3Utils.getCurrentBlockTime();
+        const latestBlockTime = await web3Utils.getLatestBlockTime();
 
         defaultOrderParams = {
             creditor: CREDITOR_1,

--- a/test/ts/unit/debt_kernel.ts
+++ b/test/ts/unit/debt_kernel.ts
@@ -31,6 +31,7 @@ import {
 import { BigNumberSetup } from "../test_utils/bignumber_setup";
 import ChaiSetup from "../test_utils/chai_setup";
 import { INVALID_OPCODE, REVERT_ERROR } from "../test_utils/constants";
+import { Web3Utils } from "../../../utils/web3_utils";
 
 import { DebtOrderFactory } from "../factories/debt_order_factory";
 
@@ -42,6 +43,9 @@ BigNumberSetup.configure();
 // Set up Chai
 ChaiSetup.configure();
 const expect = chai.expect;
+
+// Set up Web3 utils
+const web3Utils = new Web3Utils(web3);
 
 const debtKernelContract = artifacts.require("DebtKernel");
 const mockDebtTokenContract = artifacts.require("MockDebtToken");
@@ -125,6 +129,8 @@ contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
         mockDebtToken = await MockDebtTokenContract.deployed(web3, TX_DEFAULTS);
         mockPrincipalToken = await MockERC20TokenContract.deployed(web3, TX_DEFAULTS);
 
+        const latestBlockTime = await web3Utils.getCurrentBlockTime();
+
         defaultOrderParams = {
             creditor: CREDITOR_1,
             creditorFee: Units.ether(0.002),
@@ -134,8 +140,9 @@ contract("Debt Kernel (Unit Tests)", async (ACCOUNTS) => {
             debtor: DEBTOR_1,
             debtorFee: Units.ether(0.001),
             expirationTimestampInSec: new BigNumber(
-                moment()
-                    .add(1, "days")
+                moment
+                    .unix(latestBlockTime)
+                    .add(30, "days")
                     .unix(),
             ),
             issuanceVersion: repaymentRouter.address,

--- a/utils/web3_utils.ts
+++ b/utils/web3_utils.ts
@@ -17,6 +17,17 @@ export class Web3Utils {
     }
 
     /**
+     * Returns the current blocktime in seconds.
+     *
+     * @returns {Promise<number>}
+     */
+    public async getCurrentBlockTime(): Promise<number> {
+        const latestBlock = await promisify(this.web3.eth.getBlock)("latest");
+
+        return latestBlock.timestamp;
+    }
+
+    /**
      * Increases block time by the given number of seconds. Returns true
      * if the next block was mined successfully after increasing time.
      *

--- a/utils/web3_utils.ts
+++ b/utils/web3_utils.ts
@@ -17,11 +17,22 @@ export class Web3Utils {
     }
 
     /**
-     * Returns the current blocktime in seconds.
+     * Returns the latest blocktime in seconds.
      *
      * @returns {Promise<number>}
      */
-    public async getCurrentBlockTime(): Promise<number> {
+    public async getLatestBlockTime(): Promise<number> {
+        // Ganache has a bug in which, if ....
+        //   1. `evm_increaseTime` has been used at some point in the chain's history
+        //   2. `evm_revert` has *just* been used to revert to a previous snapshot
+        //   3. A block has not yet been mined
+        // ...the timestamp returned by `web3.eth.getBlock("latest")`
+        // will not account for the time differential applied by `evm_increaseTime`.
+        //
+        // We force a block to mine in order to avoid the edge case issues
+        // that this bug engenders.
+        await this.mineBlock();
+
         const latestBlock = await promisify(this.web3.eth.getBlock)("latest");
 
         return latestBlock.timestamp;


### PR DESCRIPTION
This PR introduces the following changes:

- Patches tests that rely on machine time instead of block time in order to set things like expiration tests
- Patches tests that rely on the notion of certain tokens (e.g. REP) deterministically being at certain indices (e.g. 0)