### PR TITLE
build: use deployed canonical WETH address on Kovan

### DIFF
--- a/migrations/migration_constants.js
+++ b/migrations/migration_constants.js
@@ -8,6 +8,7 @@ const SIGNATORIES = [OWNER_ONE, OWNER_TWO, OWNER_THREE, OWNER_FOUR, OWNER_FIVE];
 const THRESHOLD = 1 / 2; // 50%
 const TIMELOCK_IN_SECONDS = 60 * 60 * 24 * 7; // 7 Days
 const LIVE_NETWORK_ID = "live";
+const KOVAN_NETWORK_ID = "kovan";
 const DUMMY_TOKEN_SUPPLY = 10 ** 27;
 const DUMMY_TOKEN_DECIMALS = 18;
 
@@ -34,6 +35,16 @@ const NAMES_OF_CONTRACTS_OWNED_BY_MULTISIG = [
     "TokenRegistry",
     "ContractRegistry",
 ];
+
+/**
+ * Given that the Canonical WETH has an instance deployed onto Kovan
+ * and there are numerous tools that can be used to interact with WETH,
+ * even in a testnet context, we store its address so we can use it
+ * in our migrations.
+ *
+ * @type {String}
+ */
+export const KOVAN_WETH_ADDRESS = "0xd0a1e359811322d97991e03f863a0c30c2cf029c";
 
 /**
  * A list of the top 50 tokens by market cap, according to etherscan.io/tokens.

--- a/migrations/migration_constants.js
+++ b/migrations/migration_constants.js
@@ -44,7 +44,7 @@ const NAMES_OF_CONTRACTS_OWNED_BY_MULTISIG = [
  *
  * @type {String}
  */
-export const KOVAN_WETH_ADDRESS = "0xd0a1e359811322d97991e03f863a0c30c2cf029c";
+const KOVAN_WETH_ADDRESS = "0xd0a1e359811322d97991e03f863a0c30c2cf029c";
 
 /**
  * A list of the top 50 tokens by market cap, according to etherscan.io/tokens.
@@ -360,8 +360,10 @@ module.exports = {
     THRESHOLD,
     TIMELOCK_IN_SECONDS,
     LIVE_NETWORK_ID,
+    KOVAN_NETWORK_ID,
     DUMMY_TOKEN_SUPPLY,
     DUMMY_TOKEN_DECIMALS,
+    KOVAN_WETH_ADDRESS,
     TOKEN_LIST,
     NAMES_OF_CONTRACTS_OWNED_BY_MULTISIG,
     TOKEN_URI_OPERATOR,

--- a/migrations/utils.js
+++ b/migrations/utils.js
@@ -5,7 +5,7 @@ async function generateDummyTokens(network, DummyToken) {
         CONSTANTS.TOKEN_LIST.map(async (token) => {
             const { name, symbol, decimals } = token;
 
-            let address: string;
+            let address;
 
             // HACK: Though we usually want to deploy dummy token contracts
             // onto non-live networks, there is a canonical WETH instance

--- a/migrations/utils.js
+++ b/migrations/utils.js
@@ -1,21 +1,33 @@
 const CONSTANTS = require("./migration_constants");
 
-async function generateDummyTokens(DummyToken) {
+async function generateDummyTokens(network, DummyToken) {
     return Promise.all(
         CONSTANTS.TOKEN_LIST.map(async (token) => {
             const { name, symbol, decimals } = token;
 
-            const dummyToken = await DummyToken.new(
-                name,
-                symbol,
-                decimals,
-                CONSTANTS.DUMMY_TOKEN_SUPPLY,
-            );
+            let address: string;
+
+            // HACK: Though we usually want to deploy dummy token contracts
+            // onto non-live networks, there is a canonical WETH instance
+            // deployed on the Kovan network that it is preferrable for us
+            // to use for testing purposes.
+            if (network === CONSTANTS.KOVAN_NETWORK_ID && symbol === "WETH") {
+                address = CONSTANTS.KOVAN_WETH_ADDRESS;
+            } else {
+                const dummyToken = await DummyToken.new(
+                    name,
+                    symbol,
+                    decimals,
+                    CONSTANTS.DUMMY_TOKEN_SUPPLY,
+                );
+
+                address = dummyToken.address;
+            }
 
             return {
                 name,
                 symbol,
-                address: dummyToken.address,
+                address,
                 decimals,
             };
         }),
@@ -33,7 +45,7 @@ async function configureTokenRegistry(network, accounts, TokenRegistry, DummyTok
             break;
 
         default:
-            tokens = await generateDummyTokens(DummyToken);
+            tokens = await generateDummyTokens(network, DummyToken);
     }
 
     await Promise.all(


### PR DESCRIPTION
This PR introduces the following changes:

- Canonical WETH is deployed already on Kovan.  On Kovan, puts the canonical WETH's address in the TokenRegistry instead of deploying a whole new dummy token.

