### PR TITLE
style: issuanceHash should always be referred to as agreementId

### DIFF
--- a/contracts/DebtRegistry.sol
+++ b/contracts/DebtRegistry.sol
@@ -45,10 +45,10 @@ contract DebtRegistry is Pausable, PermissionEvents {
         uint issuanceBlockTimestamp;
     }
 
-    // Primary registry mapping issuance hashes to their corresponding entries
+    // Primary registry mapping agreement IDs to their corresponding entries
     mapping (bytes32 => Entry) internal registry;
 
-    // Maps debtor addresses to a list of their debts' issuance hashes
+    // Maps debtor addresses to a list of their debts' agreement IDs
     mapping (address => bytes32[]) internal debtorToDebts;
 
     PermissionsLib.Permissions internal entryInsertPermissions;
@@ -92,7 +92,7 @@ contract DebtRegistry is Pausable, PermissionEvents {
         _;
     }
 
-    /* Ensures an entry with the specified issuance hash exists within the debt registry. */
+    /* Ensures an entry with the specified agreement ID exists within the debt registry. */
     function doesEntryExist(bytes32 agreementId)
         public
         view
@@ -327,7 +327,7 @@ contract DebtRegistry is Pausable, PermissionEvents {
 
     /**
      * Returns the list of debt agreements a debtor is party to,
-     * with each debt agreement listed by issuance hash.
+     * with each debt agreement listed by agreement ID.
      */
     function getDebtorsDebts(address debtor)
         public

--- a/contracts/RepaymentRouter.sol
+++ b/contracts/RepaymentRouter.sol
@@ -63,7 +63,7 @@ contract RepaymentRouter is Pausable {
     }
 
     /**
-     * Given an agreement id (synonymous to 'issuanceHash' in the debt registry), routes a repayment
+     * Given an agreement id, routes a repayment
      * of a given ERC20 token to the debt's current beneficiary, and reports the repayment
      * to the debt's associated terms contract.
      */

--- a/contracts/test/mocks/MockDebtRegistry.sol
+++ b/contracts/test/mocks/MockDebtRegistry.sol
@@ -33,7 +33,7 @@ contract MockDebtRegistry is MockContract {
         uint _salt
     )
         public
-        returns (bytes32 _issuanceHash)
+        returns (bytes32 _agreementId)
     {
         bytes32 argsSignature = keccak256(
             _version,
@@ -48,120 +48,120 @@ contract MockDebtRegistry is MockContract {
 
         functionCalledWithArgs("insert", argsSignature);
 
-        bytes32 issuanceHash = getMockReturnValue("insert", DEFAULT_SIGNATURE_ARGS);
+        bytes32 agreementId = getMockReturnValue("insert", DEFAULT_SIGNATURE_ARGS);
 
-        mockGetBeneficiaryReturnValueFor(issuanceHash, _beneficiary);
+        mockGetBeneficiaryReturnValueFor(agreementId, _beneficiary);
 
-        return issuanceHash;
+        return agreementId;
     }
 
-    function modifyBeneficiary(bytes32 issuanceHash, address newBeneficiary)
+    function modifyBeneficiary(bytes32 agreementId, address newBeneficiary)
         public
     {
         functionCalledWithArgs("modifyBeneficiary",
-            keccak256(issuanceHash, newBeneficiary));
+            keccak256(agreementId, newBeneficiary));
 
-        mockGetBeneficiaryReturnValueFor(issuanceHash, newBeneficiary);
+        mockGetBeneficiaryReturnValueFor(agreementId, newBeneficiary);
     }
 
-    function getBeneficiary(bytes32 issuanceHash)
+    function getBeneficiary(bytes32 agreementId)
         public
         view
         returns (address _mockBeneficiary)
     {
-        return address(getMockReturnValue("getBeneficiary", issuanceHash));
+        return address(getMockReturnValue("getBeneficiary", agreementId));
     }
 
-    function doesEntryExist(bytes32 issuanceHash) public returns (bool) {
-        bytes32 mockReturnValue = getMockReturnValue("doesEntryExist", issuanceHash);
+    function doesEntryExist(bytes32 agreementId) public returns (bool) {
+        bytes32 mockReturnValue = getMockReturnValue("doesEntryExist", agreementId);
         return mockReturnValue == bytes32(0) ? false : true;
     }
 
-    function mockDoesEntryExist(bytes32 issuanceHash, bool exists) public {
-        mockReturnValue("doesEntryExist", issuanceHash, exists ? bytes32(1) : bytes32(0));
+    function mockDoesEntryExist(bytes32 agreementId, bool exists) public {
+        mockReturnValue("doesEntryExist", agreementId, exists ? bytes32(1) : bytes32(0));
     }
 
-    function mockInsertReturnValue(bytes32 issuanceHash) public {
-        mockReturnValue("insert", DEFAULT_SIGNATURE_ARGS, issuanceHash);
+    function mockInsertReturnValue(bytes32 agreementId) public {
+        mockReturnValue("insert", DEFAULT_SIGNATURE_ARGS, agreementId);
     }
 
-    function mockGetBeneficiaryReturnValueFor(bytes32 issuanceHash, address beneficiary)
+    function mockGetBeneficiaryReturnValueFor(bytes32 agreementId, address beneficiary)
         public
     {
-        mockReturnValue("getBeneficiary", issuanceHash, bytes32(beneficiary));
+        mockReturnValue("getBeneficiary", agreementId, bytes32(beneficiary));
     }
 
-    function getTerms(bytes32 issuanceHash)
+    function getTerms(bytes32 agreementId)
         public
         view
         returns (address _termsContract, bytes32 _termsContractParameters)
     {
         return (
-            address(getMockReturnValue("getTerms_termsContract", issuanceHash)),
-            getMockReturnValue("getTerms_termsContractParameters", issuanceHash)
+            address(getMockReturnValue("getTerms_termsContract", agreementId)),
+            getMockReturnValue("getTerms_termsContractParameters", agreementId)
         );
     }
 
     function mockGetTermsReturnValueFor(
-        bytes32 issuanceHash,
+        bytes32 agreementId,
         address termsContract,
         bytes32 termsContractParameters
     )
         public
     {
-        mockReturnValue("getTerms_termsContract", issuanceHash, bytes32(termsContract));
-        mockReturnValue("getTerms_termsContractParameters", issuanceHash, termsContractParameters);
+        mockReturnValue("getTerms_termsContract", agreementId, bytes32(termsContract));
+        mockReturnValue("getTerms_termsContractParameters", agreementId, termsContractParameters);
     }
 
-    function getTermsContract(bytes32 issuanceHash)
+    function getTermsContract(bytes32 agreementId)
         public
         view
         returns (address _termsContract)
     {
-        return address(getMockReturnValue("getTermsContract", issuanceHash));
+        return address(getMockReturnValue("getTermsContract", agreementId));
     }
 
-    function getIssuanceBlockTimestamp(bytes32 issuanceHash)
+    function getIssuanceBlockTimestamp(bytes32 agreementId)
         public
         view
         returns (uint timestamp)
     {
-        return uint(getMockReturnValue("getIssuanceBlockTimestamp", issuanceHash));
+        return uint(getMockReturnValue("getIssuanceBlockTimestamp", agreementId));
     }
 
     function mockGetIssuanceBlockTimestamp(
-        bytes32 issuanceHash,
+        bytes32 agreementId,
         uint timestamp
     )
         public
     {
-        mockReturnValue("getIssuanceBlockTimestamp", issuanceHash, bytes32(timestamp));
+        mockReturnValue("getIssuanceBlockTimestamp", agreementId, bytes32(timestamp));
     }
 
-    function getTermsContractParameters(bytes32 issuanceHash)
+    function getTermsContractParameters(bytes32 agreementId)
         public
         view
         returns (bytes32)
     {
-        return getMockReturnValue("getTermsContractParameters", issuanceHash);
+        return getMockReturnValue("getTermsContractParameters", agreementId);
     }
 
     function mockGetTermsContractParameters(
-        bytes32 issuanceHash,
+        bytes32 agreementId,
         bytes32 params
     )
         public
     {
-        mockReturnValue("getTermsContractParameters", issuanceHash, params);
+        mockReturnValue("getTermsContractParameters", agreementId, params);
     }
 
     function mockGetTermsContractReturnValueFor(
-        bytes32 issuanceHash,
+        bytes32 agreementId,
         address termsContract
     )
         public
     {
-        mockReturnValue("getTermsContract", issuanceHash, bytes32(termsContract));
+        mockReturnValue("getTermsContract", agreementId, bytes32(termsContract));
     }
 
     function wasInsertCalledWith(
@@ -190,13 +190,13 @@ contract MockDebtRegistry is MockContract {
         ));
     }
 
-    function wasModifyBeneficiaryCalledWith(bytes32 issuanceHash, address newBeneficiary)
+    function wasModifyBeneficiaryCalledWith(bytes32 agreementId, address newBeneficiary)
         public
         view
         returns (bool _wasCalled)
     {
         return wasFunctionCalledWithArgs("modifyBeneficiary",
-            keccak256(issuanceHash, newBeneficiary));
+            keccak256(agreementId, newBeneficiary));
     }
 
     function getFunctionList()

--- a/test/ts/logs/debt_kernel.ts
+++ b/test/ts/logs/debt_kernel.ts
@@ -4,24 +4,24 @@ import * as ABIDecoder from "abi-decoder";
 import { BigNumber } from "bignumber.js";
 import * as LogUtils from "./log_utils";
 
-export function LogDebtIssuance(contract: Address, issuanceHash: Bytes32): ABIDecoder.DecodedLog {
+export function LogDebtIssuance(contract: Address, agreementId: Bytes32): ABIDecoder.DecodedLog {
     return {
         address: contract,
-        events: LogUtils.getParams([["_issuanceHash", issuanceHash]]),
+        events: LogUtils.getParams([["_agreementId", agreementId]]),
         name: "LogDebtIssuance",
     };
 }
 
 export function LogTermBegin(
     contract: Address,
-    issuanceHash: Bytes32,
+    agreementId: Bytes32,
     unixTimestampSec: number,
     blockNumber: number,
 ): ABIDecoder.DecodedLog {
     return {
         address: contract,
         events: LogUtils.getParams([
-            ["_issuanceHash", issuanceHash],
+            ["_agreementId", agreementId],
             ["_unixTimestampSec", new BigNumber(unixTimestampSec)],
             ["_blockNumber", new BigNumber(blockNumber)],
         ]),
@@ -31,7 +31,7 @@ export function LogTermBegin(
 
 export function LogDebtOrderFilled(
     contract: Address,
-    issuanceHash: Bytes32,
+    agreementId: Bytes32,
     principal: BigNumber,
     principalToken: Address,
     underwriter: Address,
@@ -42,7 +42,7 @@ export function LogDebtOrderFilled(
     return {
         address: contract,
         events: LogUtils.getParams([
-            ["_issuanceHash", issuanceHash],
+            ["_agreementId", agreementId],
             ["_principal", principal],
             ["_principalToken", principalToken],
             ["_underwriter", underwriter],
@@ -56,15 +56,12 @@ export function LogDebtOrderFilled(
 
 export function LogIssuanceCancelled(
     contract: Address,
-    issuanceHash: Bytes32,
+    agreementId: Bytes32,
     cancelledBy: Address,
 ): ABIDecoder.DecodedLog {
     return {
         address: contract,
-        events: LogUtils.getParams([
-            ["_issuanceHash", issuanceHash],
-            ["_cancelledBy", cancelledBy],
-        ]),
+        events: LogUtils.getParams([["_agreementId", agreementId], ["_cancelledBy", cancelledBy]]),
         name: "LogIssuanceCancelled",
     };
 }

--- a/test/ts/logs/debt_registry.ts
+++ b/test/ts/logs/debt_registry.ts
@@ -10,7 +10,7 @@ export function LogInsertEntry(contract: Address, entry: DebtRegistryEntry): ABI
     return {
         address: contract,
         events: LogUtils.getParams([
-            ["issuanceHash", entry.getIssuanceHash()],
+            ["agreementId", entry.getIssuanceHash()],
             ["beneficiary", entry.getBeneficiary()],
             ["underwriter", entry.getUnderwriter()],
             ["underwriterRiskRating", entry.getUnderwriterRiskRating()],
@@ -23,14 +23,14 @@ export function LogInsertEntry(contract: Address, entry: DebtRegistryEntry): ABI
 
 export function LogModifyEntryBeneficiary(
     contract: Address,
-    issuanceHash: Bytes32,
+    agreementId: Bytes32,
     previousBeneficiary: Address,
     newBeneficiary: Address,
 ): ABIDecoder.DecodedLog {
     return {
         address: contract,
         events: LogUtils.getParams([
-            ["issuanceHash", issuanceHash],
+            ["agreementId", agreementId],
             ["previousBeneficiary", previousBeneficiary],
             ["newBeneficiary", newBeneficiary],
         ]),


### PR DESCRIPTION
This PR introduces the following changes:

- changes all references of `issuanceHash` to `agreementId` for consistency