### PR TITLE
Export new artifacts

### DIFF
--- a/artifacts/index.ts
+++ b/artifacts/index.ts
@@ -1,33 +1,54 @@
-import { DebtRegistry } from "./ts/DebtRegistry";
-import { DebtKernel } from "./ts/DebtKernel";
-import { RepaymentRouter } from "./ts/RepaymentRouter";
-import { TokenTransferProxy } from "./ts/TokenTransferProxy";
-import { TokenRegistry } from "./ts/TokenRegistry";
-import { DebtToken } from "./ts/DebtToken";
-import { DummyToken } from "./ts/DummyToken";
-import { ERC20 } from "./ts/ERC20";
-import { SimpleInterestTermsContract } from "./ts/SimpleInterestTermsContract";
-import { CollateralizedSimpleInterestTermsContract } from "./ts/CollateralizedSimpleInterestTermsContract";
-import { TermsContract } from "./ts/TermsContract";
-import { Collateralizer } from "./ts/Collateralizer";
-import { ERC721Receiver } from "./ts/ERC721Receiver";
-import { MockERC721Receiver } from "./ts/MockERC721Receiver";
-import { ContractRegistry } from "./ts/ContractRegistry";
+/************************************
+ *  Core Dharma Protocol Contracts  *
+ ************************************/
+// A contract for handling the filling of debt orders.
+export { DebtKernel } from "./ts/DebtKernel";
+// A contract for storing detailed information about debt agreements.
+export { DebtRegistry } from "./ts/DebtRegistry";
+// A contract for handling loan repayments.
+export { RepaymentRouter } from "./ts/RepaymentRouter";
+// A contract used for transferring ERC20 tokens among various agents.
+export { TokenTransferProxy } from "./ts/TokenTransferProxy";
+// Stores the addresses of core Dharma Protocol Contracts.
+export { ContractRegistry } from "./ts/ContractRegistry";
+// A prototype for terms contracts.
+export { TermsContract } from "./ts/TermsContract";
+// A wrapper for the Dharma Debt Token (ERC721 standard.)
+export { DebtToken } from "./ts/DebtToken";
 
-export {
-    DebtRegistry,
-    DebtKernel,
-    RepaymentRouter,
-    TokenTransferProxy,
-    TokenRegistry,
-    DebtToken,
-    DummyToken,
-    ERC20,
-    SimpleInterestTermsContract,
-    CollateralizedSimpleInterestTermsContract,
-    TermsContract,
-    Collateralizer,
-    ERC721Receiver,
-    MockERC721Receiver,
-    ContractRegistry,
-};
+/************************************
+ *  ERC20 Simple Interest Contracts *
+ ************************************/
+// A contract for storing the addresses of ERC20 contracts.
+export { TokenRegistry } from "./ts/TokenRegistry";
+// Used to store ("lock") ERC20 collateral used in debt agreements.
+export { Collateralizer } from "./ts/Collateralizer";
+// A abstract terms contract for simple interest loans.
+export { SimpleInterestTermsContract } from "./ts/SimpleInterestTermsContract";
+// A terms contract for creating ERC20-collateralized simple interest terms debt agreements.
+export { CollateralizedSimpleInterestTermsContract } from "./ts/CollateralizedSimpleInterestTermsContract";
+// A wrapper for the ERC20 token standard.
+export { ERC20 } from "./ts/ERC20";
+// Used for creating test ERC20 tokens during development and on test networks like Kovan.
+export { DummyToken } from "./ts/DummyToken";
+
+/********************************
+ *  ERC721 Collateral Contracts *
+ ********************************/
+// A terms contract for creating ERC721-collateralized simple interest debt agreements.
+export { ERC721CollateralizedSimpleInterestTermsContract } from "./ts/ERC721CollateralizedSimpleInterestTermsContract";
+// A contract to store (or "lock") ERC721 assets that are used in debt agreements.
+export { ERC721Collateralizer } from "./ts/ERC721Collateralizer";
+// A contract used to reference the addresses of various ERC721 contracts.
+export { ERC721TokenRegistry } from "./ts/ERC721TokenRegistry";
+// An ERC721 contract with the ability to mint tokens -- for test purposes.
+export { MintableERC721Token } from "./ts/MintableERC721Token";
+
+/********************
+ *  Misc. Contracts *
+ ********************/
+export { ERC721Receiver } from "./ts/ERC721Receiver";
+export { MockERC721Receiver } from "./ts/MockERC721Receiver";
+// The core CryptoKitties contract -- used for testing collateralizing CryptoKitties, which
+// are a non-standard NFT.
+export { KittyCore } from "./ts/KittyCore";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "charta",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "charta",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dharmaprotocol/contracts",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "dist/artifacts/index.js",
   "typings": "dist/types/artifacts/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dharmaprotocol/contracts",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "dist/artifacts/index.js",
   "typings": "dist/types/artifacts/index.d.ts",
   "files": [


### PR DESCRIPTION
For the actual new artifacts (which is not human-readable), see: https://github.com/dharmaprotocol/charta/pull/152

Note on the version seeming to go from 0.1.4 => 0.1.6:
This is just because master is 1 commit behind (see https://github.com/dharmaprotocol/charta/pull/150), so this will bring it up-to-date.
